### PR TITLE
Create photo_view_swipe.dart

### DIFF
--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -7,7 +7,6 @@ class PhotoViewSwipe extends StatefulWidget {
     @required this.imageProvider,
     this.dragBgColor, // default Colors.black.withOpacity(0.5)
     this.dragDistance, // default 160
-    this.photoBackground, // deafult Colors.black
 
     // Standard photo_view
     this.loadingBuilder,
@@ -37,7 +36,6 @@ class PhotoViewSwipe extends StatefulWidget {
   final ImageProvider imageProvider;
   final Color dragBgColor;
   final double dragDistance;
-  final Color photoBackground;
 
   // Standard photo_view
   final LoadingBuilder loadingBuilder;
@@ -95,9 +93,7 @@ class _PhotoViewSwipeState extends State<PhotoViewSwipe> {
               child: Container(
                 decoration: _position.dy == 0.0
                     ? (widget.backgroundDecoration ??
-                        BoxDecoration(
-                          color: (widget.photoBackground ?? Colors.black),
-                        ))
+                        BoxDecoration(color: Colors.black))
                     : null,
                 height: MediaQuery.of(context).size.height,
                 width: MediaQuery.of(context).size.width,

--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -73,7 +73,7 @@ class _PhotoViewSwipeState extends State<PhotoViewSwipe> {
     scaleStateController = PhotoViewScaleStateController();
     scaleStateController.outputScaleStateStream.listen((event) {
       setState(() {
-        _isZoomed = event != PhotoViewScaleState.zoomedOut ||
+        _isZoomed = event != PhotoViewScaleState.zoomedOut &&
             event != PhotoViewScaleState.initial;
       });
     });

--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -94,9 +94,10 @@ class _PhotoViewSwipeState extends State<PhotoViewSwipe> {
               },
               child: Container(
                 decoration: _position.dy == 0.0
-                    ? BoxDecoration(
-                        color: (widget.photoBackground ?? Colors.black),
-                      )
+                    ? (widget.backgroundDecoration ??
+                        BoxDecoration(
+                          color: (widget.photoBackground ?? Colors.black),
+                        ))
                     : null,
                 height: MediaQuery.of(context).size.height,
                 width: MediaQuery.of(context).size.width,

--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+
+class PhotoViewSwipe extends StatefulWidget {
+  PhotoViewSwipe({
+    Key key,
+    @required this.imageProvider,
+    this.dragBgColor, // default Colors.black.withOpacity(0.5)
+    this.dragDistance, // default 160
+    this.photoBackground, // deafult Colors.black
+
+    // Standard photo_view
+    this.loadingBuilder,
+    this.loadFailedChild,
+    this.backgroundDecoration,
+    this.gaplessPlayback = false,
+    this.heroAttributes,
+    this.scaleStateChangedCallback,
+    this.enableRotation = false,
+    this.controller,
+    this.scaleStateController,
+    this.maxScale,
+    this.minScale,
+    this.initialScale,
+    this.basePosition,
+    this.scaleStateCycle,
+    this.onTapUp,
+    this.onTapDown,
+    this.customSize,
+    this.gestureDetectorBehavior,
+    this.tightMode,
+    this.filterQuality,
+  })  : child = null,
+        childSize = null,
+        super(key: key);
+
+  final ImageProvider imageProvider;
+  final Color dragBgColor;
+  final double dragDistance;
+  final Color photoBackground;
+
+  // Standard photo_view
+  final LoadingBuilder loadingBuilder;
+  final Widget loadFailedChild;
+  final Decoration backgroundDecoration;
+  final bool gaplessPlayback;
+  final PhotoViewHeroAttributes heroAttributes;
+  final Size customSize;
+  final ValueChanged<PhotoViewScaleState> scaleStateChangedCallback;
+  final bool enableRotation;
+  final Widget child;
+  final Size childSize;
+  final dynamic maxScale;
+  final dynamic minScale;
+  final dynamic initialScale;
+  final PhotoViewControllerBase controller;
+  final PhotoViewScaleStateController scaleStateController;
+  final Alignment basePosition;
+  final ScaleStateCycle scaleStateCycle;
+  final PhotoViewImageTapUpCallback onTapUp;
+  final PhotoViewImageTapDownCallback onTapDown;
+  final HitTestBehavior gestureDetectorBehavior;
+  final bool tightMode;
+  final FilterQuality filterQuality;
+
+  @override
+  _PhotoViewSwipeState createState() => _PhotoViewSwipeState();
+}
+
+class _PhotoViewSwipeState extends State<PhotoViewSwipe> {
+  Offset _position = Offset(0.0, 0.0);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: widget.dragBgColor ?? Colors.black.withOpacity(0.5),
+      body: Stack(
+        children: [
+          Positioned(
+            left: _position.dx,
+            top: _position.dy,
+            child: GestureDetector(
+              onVerticalDragUpdate: (details) {
+                setState(() =>
+                    _position = Offset(0.0, _position.dy + details.delta.dy));
+              },
+              onVerticalDragEnd: (details) {
+                double pixelsPerSecond = _position.dy.abs();
+                if (pixelsPerSecond > (widget.dragDistance ?? 160)) {
+                  Navigator.pop(context);
+                } else {
+                  setState(() => _position = Offset(0.0, 0.0));
+                }
+              },
+              child: Container(
+                decoration: _position.dy == 0.0
+                    ? BoxDecoration(
+                        color: (widget.photoBackground ?? Colors.black),
+                      )
+                    : null,
+                height: MediaQuery.of(context).size.height,
+                width: MediaQuery.of(context).size.width,
+                child: PhotoView(
+                  imageProvider: widget.imageProvider,
+                  backgroundDecoration:
+                      BoxDecoration(color: Colors.transparent),
+                  loadingBuilder: widget.loadingBuilder,
+                  loadFailedChild: widget.loadFailedChild,
+                  gaplessPlayback: widget.gaplessPlayback,
+                  heroAttributes: widget.heroAttributes,
+                  scaleStateChangedCallback: widget.scaleStateChangedCallback,
+                  enableRotation: widget.enableRotation,
+                  controller: widget.controller,
+                  scaleStateController: widget.scaleStateController,
+                  maxScale: widget.maxScale,
+                  minScale: widget.minScale,
+                  initialScale: widget.initialScale,
+                  basePosition: widget.basePosition,
+                  scaleStateCycle: widget.scaleStateCycle,
+                  onTapUp: widget.onTapUp,
+                  onTapDown: widget.onTapDown,
+                  customSize: widget.customSize,
+                  gestureDetectorBehavior: widget.gestureDetectorBehavior,
+                  tightMode: widget.tightMode,
+                  filterQuality: widget.filterQuality,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
 

--- a/lib/photo_view_swipe.dart
+++ b/lib/photo_view_swipe.dart
@@ -73,8 +73,8 @@ class _PhotoViewSwipeState extends State<PhotoViewSwipe> {
     scaleStateController = PhotoViewScaleStateController();
     scaleStateController.outputScaleStateStream.listen((event) {
       setState(() {
-        _isZoomed =
-            scaleStateController.scaleState == PhotoViewScaleState.zoomedIn;
+        _isZoomed = event != PhotoViewScaleState.zoomedOut ||
+            event != PhotoViewScaleState.initial;
       });
     });
 


### PR DESCRIPTION
Initially I thought it would be easier to check with a separate class, if it works out maybe it can be merged to the main `PhotoView`.

I first thought of using `Draggable`, but `GestureDetector` seems to be the way to detect both `scale` and `drag` actions at the same time. After testing for a while, I noticed that if the scale gesture is not made well the widget can assume this is a drag gesture, but I'm not sure how much of a problem this is, might be worth checking out.

Another note is that I had to add `backgroundDecoration: BoxDecoration(color: Colors.transparent),` to `PhotoView`, otherwise it would leave a trace of the background color during dismiss. Instead, I added the `backgroundDecoration` to the `Container`, which fixes this problem.

And the final catch would be that for having a nice look while dragging, we need a transparent background on the page, so the navigation should be made like:

```
Navigator.of(context).push(
  PageRouteBuilder(
    opaque: false,
    pageBuilder: (_, __, ___) => ImageDisplay(),
  ),
);
```

It can simply be tested like below:

```
class ImageDisplay {
...

@override
  Widget build(BuildContext context) {
    return Scaffold(
      backgroundColor: Colors.transparent,
      body: PhotoViewSwipe(
        heroAttributes: PhotoViewHeroAttributes(tag: 'imageHero'),
        imageProvider: FileImage(
          File(_uri),
        ),
      ),
    );
  }
```

### Note:
Just realised that if the image is zoomed, the pan gesture would immediately start dragging, so as a work-around, I took over `PhotoViewScaleStateController` and if the image is zoomed it wouldn't try to drag and dismiss the image away.

Here is a preview:
![swipe](https://user-images.githubusercontent.com/15243788/79176228-efb57300-7dff-11ea-8de0-cea27ad8cf7e.gif)