### PR TITLE
Fix bug with translation after scale.

### DIFF
--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -142,10 +142,9 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
     updateScaleStateFromNewScale(newScale);
 
-    //
     updateMultiple(
       scale: newScale,
-      position: clampPosition(position: delta * details.scale),
+      position: clampPosition(position: delta),
       rotation:
           widget.enableRotation ? _rotationBefore + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,


### PR DESCRIPTION
After scaling (zooming in), translation was multiplied by the scaling
factor, leading to an unexpected user experience (the
image would translate faster than finger movement).