### PR TITLE
Fix error builder to be (ever) called; Remove deprecated loading child

### DIFF
--- a/example/lib/screens/common/app_bar.dart
+++ b/example/lib/screens/common/app_bar.dart
@@ -14,8 +14,9 @@ class ExampleAppBar extends StatelessWidget {
         decoration: const BoxDecoration(
             color: Colors.white,
             borderRadius: const BorderRadius.only(
-                bottomLeft: const Radius.circular(10.0),
-                bottomRight: const Radius.circular(10.0)),
+              bottomLeft: const Radius.circular(10.0),
+              bottomRight: const Radius.circular(10.0),
+            ),
             boxShadow: <BoxShadow>[
               const BoxShadow(
                   color: Colors.black12, spreadRadius: 10.0, blurRadius: 20.0)

--- a/example/lib/screens/common/common_example_wrapper.dart
+++ b/example/lib/screens/common/common_example_wrapper.dart
@@ -12,6 +12,7 @@ class CommonExampleRouteWrapper extends StatelessWidget {
     this.basePosition = Alignment.center,
     this.filterQuality = FilterQuality.none,
     this.disableGestures,
+    this.errorBuilder,
   });
 
   final ImageProvider imageProvider;
@@ -23,6 +24,7 @@ class CommonExampleRouteWrapper extends StatelessWidget {
   final Alignment basePosition;
   final FilterQuality filterQuality;
   final bool disableGestures;
+  final ImageErrorWidgetBuilder errorBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +43,7 @@ class CommonExampleRouteWrapper extends StatelessWidget {
           basePosition: basePosition,
           filterQuality: filterQuality,
           disableGestures: disableGestures,
+          errorBuilder: errorBuilder,
         ),
       ),
     );

--- a/example/lib/screens/examples/network-images.dart
+++ b/example/lib/screens/examples/network-images.dart
@@ -50,11 +50,39 @@ class NetworkExamples extends StatelessWidget {
                     imageProvider: const NetworkImage(
                       "https://pudim.com.br/sss.jpg",
                     ),
+                    backgroundDecoration: BoxDecoration(
+                      color: Color(0xffa1a1a1),
+                    ),
                   ),
                 ),
               );
             },
-          )
+          ),
+          ExampleButtonNode(
+            title: "Error image with custom error screen",
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => CommonExampleRouteWrapper(
+                    imageProvider: const NetworkImage(
+                      "https://pudim.com.br/sss.jpg",
+                    ),
+                    errorBuilder: (_, __, ___) {
+                      return Container(
+                        child: Column(
+                          children: [
+                            Image.asset("assets/neat.gif"),
+                            const Text("well, that went badly"),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );

--- a/example/lib/screens/examples/rotation_examples.dart
+++ b/example/lib/screens/examples/rotation_examples.dart
@@ -98,7 +98,7 @@ class _ProgrammaticRotationExampleState
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        child: Icon(Icons.rotate_right),
+        child: const Icon(Icons.rotate_right),
         onPressed: _rotateRight90Degrees,
       ),
     );

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -236,7 +236,6 @@ class PhotoView extends StatefulWidget {
     Key key,
     @required this.imageProvider,
     this.loadingBuilder,
-    this.loadFailedChild,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
     this.heroAttributes,
@@ -289,8 +288,7 @@ class PhotoView extends StatefulWidget {
     this.tightMode,
     this.filterQuality,
     this.disableGestures,
-  })  : loadFailedChild = null,
-        errorBuilder = null,
+  })  : errorBuilder = null,
         imageProvider = null,
         gaplessPlayback = false,
         loadingBuilder = null,
@@ -306,10 +304,6 @@ class PhotoView extends StatefulWidget {
 
   /// Show loadFailedChild when the image failed to load
   final ImageErrorWidgetBuilder errorBuilder;
-
-  /// Show loadFailedChild when the image failed to load
-  @Deprecated("Use errorBuilder instead")
-  final Widget loadFailedChild;
 
   /// Changes the background behind image, defaults to `Colors.black`.
   final Decoration backgroundDecoration;
@@ -506,7 +500,6 @@ class _PhotoViewState extends State<PhotoView> {
             : ImageWrapper(
                 imageProvider: widget.imageProvider,
                 loadingBuilder: widget.loadingBuilder,
-                loadFailedChild: widget.loadFailedChild,
                 backgroundDecoration: widget.backgroundDecoration,
                 gaplessPlayback: widget.gaplessPlayback,
                 heroAttributes: widget.heroAttributes,
@@ -526,6 +519,7 @@ class _PhotoViewState extends State<PhotoView> {
                 tightMode: widget.tightMode,
                 filterQuality: widget.filterQuality,
                 disableGestures: widget.disableGestures,
+                errorBuilder: widget.errorBuilder,
               );
       },
     );

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -103,7 +103,6 @@ class PhotoViewGallery extends StatefulWidget {
     Key key,
     @required this.pageOptions,
     this.loadingBuilder,
-    this.loadFailedChild,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
     this.reverse = false,
@@ -127,7 +126,6 @@ class PhotoViewGallery extends StatefulWidget {
     @required this.itemCount,
     @required this.builder,
     this.loadingBuilder,
-    this.loadFailedChild,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
     this.reverse = false,
@@ -157,9 +155,6 @@ class PhotoViewGallery extends StatefulWidget {
 
   /// Mirror to [PhotoView.loadingBuilder]
   final LoadingBuilder loadingBuilder;
-
-  /// Mirror to [PhotoView.loadFailedChild]
-  final Widget loadFailedChild;
 
   /// Mirror to [PhotoView.backgroundDecoration]
   final Decoration backgroundDecoration;
@@ -271,7 +266,6 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             key: ObjectKey(index),
             imageProvider: pageOption.imageProvider,
             loadingBuilder: widget.loadingBuilder,
-            loadFailedChild: widget.loadFailedChild,
             backgroundDecoration: widget.backgroundDecoration,
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,
@@ -291,6 +285,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             filterQuality: pageOption.filterQuality,
             basePosition: pageOption.basePosition,
             disableGestures: pageOption.disableGestures,
+            errorBuilder: pageOption.errorBuilder,
           );
 
     return ClipRect(
@@ -329,6 +324,7 @@ class PhotoViewGalleryPageOptions {
     this.tightMode,
     this.filterQuality,
     this.disableGestures,
+    this.errorBuilder,
   })  : child = null,
         childSize = null,
         assert(imageProvider != null);
@@ -350,7 +346,8 @@ class PhotoViewGalleryPageOptions {
     this.tightMode,
     this.filterQuality,
     this.disableGestures,
-  })  : imageProvider = null,
+  })  : errorBuilder = null,
+        imageProvider = null,
         assert(child != null);
 
   /// Mirror to [PhotoView.imageProvider]
@@ -403,4 +400,7 @@ class PhotoViewGalleryPageOptions {
 
   /// Quality levels for image filters.
   final FilterQuality filterQuality;
+
+  /// Mirror to [PhotoView.errorBuilder]
+  final ImageErrorWidgetBuilder errorBuilder;
 }

--- a/lib/src/core/photo_view_hit_corners.dart
+++ b/lib/src/core/photo_view_hit_corners.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:photo_view/src/controller/photo_view_controller_delegate.dart'

--- a/lib/src/photo_view_default_widgets.dart
+++ b/lib/src/photo_view_default_widgets.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
 
 class PhotoViewDefaultError extends StatelessWidget {
+  const PhotoViewDefaultError({Key key, @required this.decoration})
+      : super(key: key);
+
+  final BoxDecoration decoration;
+
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Icon(
-        Icons.broken_image,
-        color: Colors.grey[400],
-        size: 40.0,
+    return DecoratedBox(
+      decoration: decoration,
+      child: Center(
+        child: Icon(
+          Icons.broken_image,
+          color: Colors.grey[400],
+          size: 40.0,
+        ),
       ),
     );
   }

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -8,35 +8,33 @@ import 'utils/photo_view_utils.dart';
 class ImageWrapper extends StatefulWidget {
   const ImageWrapper({
     Key key,
-    this.imageProvider,
-    this.loadingBuilder,
-    this.loadFailedChild,
-    this.backgroundDecoration,
-    this.gaplessPlayback = false,
-    this.heroAttributes,
-    this.scaleStateChangedCallback,
-    this.enableRotation = false,
-    this.controller,
-    this.scaleStateController,
-    this.maxScale,
-    this.minScale,
-    this.initialScale,
-    this.basePosition,
-    this.scaleStateCycle,
-    this.onTapUp,
-    this.onTapDown,
-    this.outerSize,
-    this.gestureDetectorBehavior,
-    this.tightMode,
-    this.filterQuality,
-    this.disableGestures,
-    this.errorBuilder,
+    @required this.imageProvider,
+    @required this.loadingBuilder,
+    @required this.backgroundDecoration,
+    @required this.gaplessPlayback,
+    @required this.heroAttributes,
+    @required this.scaleStateChangedCallback,
+    @required this.enableRotation,
+    @required this.controller,
+    @required this.scaleStateController,
+    @required this.maxScale,
+    @required this.minScale,
+    @required this.initialScale,
+    @required this.basePosition,
+    @required this.scaleStateCycle,
+    @required this.onTapUp,
+    @required this.onTapDown,
+    @required this.outerSize,
+    @required this.gestureDetectorBehavior,
+    @required this.tightMode,
+    @required this.filterQuality,
+    @required this.disableGestures,
+    @required this.errorBuilder,
   }) : super(key: key);
 
   final ImageProvider imageProvider;
   final LoadingBuilder loadingBuilder;
   final ImageErrorWidgetBuilder errorBuilder;
-  final Widget loadFailedChild;
   final Decoration backgroundDecoration;
   final bool gaplessPlayback;
   final PhotoViewHeroAttributes heroAttributes;
@@ -49,10 +47,8 @@ class ImageWrapper extends StatefulWidget {
   final PhotoViewScaleStateController scaleStateController;
   final Alignment basePosition;
   final ScaleStateCycle scaleStateCycle;
-
   final PhotoViewImageTapUpCallback onTapUp;
   final PhotoViewImageTapDownCallback onTapDown;
-
   final Size outerSize;
   final HitTestBehavior gestureDetectorBehavior;
   final bool tightMode;
@@ -121,12 +117,10 @@ class _ImageWrapperState extends State<ImageWrapper> {
   }
 
   void _updateSourceStream(ImageStream newStream) {
-    if (_imageStream != null) {
-      if (_imageStream?.key == newStream.key) {
-        return;
-      }
-      _imageStream.removeListener(_imageStreamListener);
+    if (_imageStream?.key == newStream.key) {
+      return;
     }
+    _imageStream?.removeListener(_imageStreamListener);
     _imageStream = newStream;
     _imageStream.addListener(_getOrCreateListener());
   }
@@ -208,39 +202,38 @@ class _ImageWrapperState extends State<ImageWrapper> {
   Widget _buildError(
     BuildContext context,
   ) {
-    if (widget.loadFailedChild != null) {
-      return widget.loadFailedChild;
-    }
     if (widget.errorBuilder != null) {
       return widget.errorBuilder(context, _lastException, _stackTrace);
     }
-    return PhotoViewDefaultError();
+    return PhotoViewDefaultError(
+      decoration: widget.backgroundDecoration,
+    );
   }
 }
 
 class CustomChildWrapper extends StatelessWidget {
   const CustomChildWrapper({
     Key key,
-    this.child,
-    this.childSize,
-    this.backgroundDecoration,
-    this.heroAttributes,
-    this.scaleStateChangedCallback,
-    this.enableRotation,
-    this.controller,
-    this.scaleStateController,
-    this.maxScale,
-    this.minScale,
-    this.initialScale,
-    this.basePosition,
-    this.scaleStateCycle,
-    this.onTapUp,
-    this.onTapDown,
-    this.outerSize,
-    this.gestureDetectorBehavior,
-    this.tightMode,
-    this.filterQuality,
-    this.disableGestures,
+    @required this.child,
+    @required this.childSize,
+    @required this.backgroundDecoration,
+    @required this.heroAttributes,
+    @required this.scaleStateChangedCallback,
+    @required this.enableRotation,
+    @required this.controller,
+    @required this.scaleStateController,
+    @required this.maxScale,
+    @required this.minScale,
+    @required this.initialScale,
+    @required this.basePosition,
+    @required this.scaleStateCycle,
+    @required this.onTapUp,
+    @required this.onTapDown,
+    @required this.outerSize,
+    @required this.gestureDetectorBehavior,
+    @required this.tightMode,
+    @required this.filterQuality,
+    @required this.disableGestures,
   }) : super(key: key);
 
   final Widget child;


### PR DESCRIPTION
This PR fixes some issues regarding error builder.
- fix #337. 
- Remove deprecated `loadingChild`
- Makes `backgroundDecoration` to be the background of the default error icon.