### PR TITLE
Migrated to Sound Null Safety

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"dart.lineLength": 80
+}

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -48,3 +48,4 @@ macos/
 ios/
 android/
 web/
+.fvm/

--- a/example/lib/screens/common/app_bar.dart
+++ b/example/lib/screens/common/app_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ExampleAppBar extends StatelessWidget {
-  const ExampleAppBar({this.title, this.showGoBack = false}) : super();
+  const ExampleAppBar({required this.title, this.showGoBack = false}) : super();
 
   final String title;
   final bool showGoBack;
@@ -52,10 +52,10 @@ class ExampleAppBar extends StatelessWidget {
 
 class ExampleAppBarLayout extends StatelessWidget {
   const ExampleAppBarLayout({
-    Key key,
-    @required this.title,
-    this.showGoBack,
-    this.child,
+    Key? key,
+    required this.title,
+    this.showGoBack = false,
+    required this.child,
   }) : super(key: key);
 
   final String title;

--- a/example/lib/screens/common/common_example_wrapper.dart
+++ b/example/lib/screens/common/common_example_wrapper.dart
@@ -15,16 +15,16 @@ class CommonExampleRouteWrapper extends StatelessWidget {
     this.errorBuilder,
   });
 
-  final ImageProvider imageProvider;
-  final LoadingBuilder loadingBuilder;
-  final Decoration backgroundDecoration;
+  final ImageProvider? imageProvider;
+  final LoadingBuilder? loadingBuilder;
+  final BoxDecoration? backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
   final dynamic initialScale;
   final Alignment basePosition;
   final FilterQuality filterQuality;
-  final bool disableGestures;
-  final ImageErrorWidgetBuilder errorBuilder;
+  final bool? disableGestures;
+  final ImageErrorWidgetBuilder? errorBuilder;
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/screens/common/example_button.dart
+++ b/example/lib/screens/common/example_button.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 
 class ExampleButtonNode extends StatelessWidget {
   const ExampleButtonNode({
-    this.title,
-    this.onPressed,
+    required this.title,
+    required this.onPressed,
   });
 
   final String title;
-  final Function onPressed;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/screens/common/example_button.dart
+++ b/example/lib/screens/common/example_button.dart
@@ -30,10 +30,12 @@ class ExampleButtonNode extends StatelessWidget {
             margin: const EdgeInsets.only(
               top: 10.0,
             ),
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: onPressed,
               child: const Text("Open example"),
-              color: Colors.amber,
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(Colors.amber),
+              ),
             ),
           )
         ],

--- a/example/lib/screens/examples/common_use_cases_examples.dart
+++ b/example/lib/screens/examples/common_use_cases_examples.dart
@@ -153,7 +153,7 @@ class CommonUseCasesExamples extends StatelessWidget {
 
 class OneTapWrapper extends StatelessWidget {
   const OneTapWrapper({
-    this.imageProvider,
+    required this.imageProvider,
   });
 
   final ImageProvider imageProvider;

--- a/example/lib/screens/examples/controller_example.dart
+++ b/example/lib/screens/examples/controller_example.dart
@@ -17,8 +17,8 @@ const double defScale = 0.1;
 const double maxScale = 0.6;
 
 class _ControllerExampleState extends State<ControllerExample> {
-  PhotoViewControllerBase controller;
-  PhotoViewScaleStateController scaleStateController;
+  late PhotoViewControllerBase controller;
+  late PhotoViewScaleStateController scaleStateController;
 
   int calls = 0;
 
@@ -28,8 +28,7 @@ class _ControllerExampleState extends State<ControllerExample> {
       ..scale = defScale
       ..outputStateStream.listen(onController);
 
-    scaleStateController = PhotoViewScaleStateController()
-      ..outputScaleStateStream.listen(onScaleState);
+    scaleStateController = PhotoViewScaleStateController()..outputScaleStateStream.listen(onScaleState);
     super.initState();
   }
 
@@ -101,8 +100,7 @@ class _ControllerExampleState extends State<ControllerExample> {
           style: const TextStyle(color: Colors.white),
         ),
         SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-              activeTrackColor: Colors.orange, thumbColor: Colors.orange),
+          data: SliderTheme.of(context).copyWith(activeTrackColor: Colors.orange, thumbColor: Colors.orange),
           child: Slider(
             value: value.rotation.clamp(min, max),
             min: min,
@@ -122,7 +120,7 @@ class _ControllerExampleState extends State<ControllerExample> {
             thumbColor: Colors.orange,
           ),
           child: Slider(
-            value: value.scale.clamp(minScale, maxScale),
+            value: value.scale!.clamp(minScale, maxScale),
             min: minScale,
             max: maxScale,
             onChanged: (double newScale) {

--- a/example/lib/screens/examples/dialog_example.dart
+++ b/example/lib/screens/examples/dialog_example.dart
@@ -8,92 +8,87 @@ class DialogExample extends StatefulWidget {
 }
 
 class _DialogExampleState extends State<DialogExample> {
-  VoidCallback openDialog(BuildContext context) => () {
-        showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return Dialog(
-              child: Container(
+  void openDialog(BuildContext context) => showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return Dialog(
+            child: Container(
+              child: PhotoView(
+                tightMode: true,
+                imageProvider: const AssetImage("assets/large-image.jpg"),
+                heroAttributes: const PhotoViewHeroAttributes(tag: "someTag"),
+              ),
+            ),
+          );
+        },
+      );
+
+  void openBottomSheet(BuildContext context) => showBottomSheet(
+        context: context,
+        backgroundColor: Colors.transparent,
+        shape: const ContinuousRectangleBorder(),
+        builder: (BuildContext context) {
+          return PhotoViewGestureDetectorScope(
+            axis: Axis.vertical,
+            child: PhotoView(
+              backgroundDecoration: BoxDecoration(
+                color: Colors.black.withAlpha(240),
+              ),
+              imageProvider: const AssetImage("assets/large-image.jpg"),
+              heroAttributes: const PhotoViewHeroAttributes(tag: "someTag"),
+            ),
+          );
+        },
+      );
+
+  void openBottomSheetModal(BuildContext context) => showModalBottomSheet(
+        context: context,
+        shape: const ContinuousRectangleBorder(),
+        builder: (BuildContext context) {
+          return SafeArea(
+            child: Container(
+              height: 250,
+              child: PhotoViewGestureDetectorScope(
+                axis: Axis.vertical,
                 child: PhotoView(
                   tightMode: true,
                   imageProvider: const AssetImage("assets/large-image.jpg"),
                   heroAttributes: const PhotoViewHeroAttributes(tag: "someTag"),
                 ),
               ),
-            );
-          },
-        );
-      };
-
-  VoidCallback openBottomSheet(BuildContext context) => () {
-        showBottomSheet(
-          context: context,
-          backgroundColor: Colors.transparent,
-          shape: const ContinuousRectangleBorder(),
-          builder: (BuildContext context) {
-            return PhotoViewGestureDetectorScope(
-              axis: Axis.vertical,
-              child: PhotoView(
-                backgroundDecoration: BoxDecoration(
-                  color: Colors.black.withAlpha(240),
-                ),
-                imageProvider: const AssetImage("assets/large-image.jpg"),
-                heroAttributes: const PhotoViewHeroAttributes(tag: "someTag"),
-              ),
-            );
-          },
-        );
-      };
-
-  VoidCallback openBottomSheetModal(BuildContext context) => () {
-        showModalBottomSheet(
-          context: context,
-          shape: const ContinuousRectangleBorder(),
-          builder: (BuildContext context) {
-            return SafeArea(
-              child: Container(
-                height: 250,
-                child: PhotoViewGestureDetectorScope(
-                  axis: Axis.vertical,
-                  child: PhotoView(
-                    tightMode: true,
-                    imageProvider: const AssetImage("assets/large-image.jpg"),
-                    heroAttributes:
-                        const PhotoViewHeroAttributes(tag: "someTag"),
-                  ),
-                ),
-              ),
-            );
-          },
-        );
-      };
+            ),
+          );
+        },
+      );
 
   @override
   Widget build(BuildContext context) {
     return ExampleAppBarLayout(
       title: "Dialogs integration",
       showGoBack: true,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Container(
-            decoration: const BoxDecoration(color: Colors.red),
-          ),
-          RaisedButton(
-            child: const Text("Dialog"),
-            onPressed: openDialog(context),
-          ),
-          const Divider(),
-          RaisedButton(
-            child: const Text("Bottom sheet"),
-            onPressed: openBottomSheet(context),
-          ),
-          const Divider(),
-          RaisedButton(
-            child: const Text("Bottom sheet tight mode"),
-            onPressed: openBottomSheetModal(context),
-          ),
-        ],
+      child: Builder(
+        builder: (context) => Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Container(
+              decoration: const BoxDecoration(color: Colors.red),
+            ),
+            ElevatedButton(
+              child: const Text("Dialog"),
+              onPressed: () => openDialog(context),
+            ),
+            const Divider(),
+            ElevatedButton(
+              child: const Text("Bottom sheet"),
+              onPressed: () => openBottomSheet(context),
+            ),
+            const Divider(),
+            ElevatedButton(
+              child: const Text("Bottom sheet tight mode"),
+              onPressed: () => openBottomSheetModal(context),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/example/lib/screens/examples/gallery/gallery_example.dart
+++ b/example/lib/screens/examples/gallery/gallery_example.dart
@@ -53,7 +53,7 @@ class _GalleryExampleState extends State<GalleryExample> {
                   value: verticalGallery,
                   onChanged: (value) {
                     setState(() {
-                      verticalGallery = value;
+                      verticalGallery = value!;
                     });
                   },
                 ),
@@ -88,13 +88,13 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
     this.backgroundDecoration,
     this.minScale,
     this.maxScale,
-    this.initialIndex,
-    @required this.galleryItems,
+    this.initialIndex = 0,
+    required this.galleryItems,
     this.scrollDirection = Axis.horizontal,
   }) : pageController = PageController(initialPage: initialIndex);
 
-  final LoadingBuilder loadingBuilder;
-  final Decoration backgroundDecoration;
+  final LoadingBuilder? loadingBuilder;
+  final BoxDecoration? backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
   final int initialIndex;
@@ -109,13 +109,7 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
 }
 
 class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
-  int currentIndex;
-
-  @override
-  void initState() {
-    currentIndex = widget.initialIndex;
-    super.initState();
-  }
+  late int currentIndex = widget.initialIndex;
 
   void onPageChanged(int index) {
     setState(() {

--- a/example/lib/screens/examples/gallery/gallery_example_item.dart
+++ b/example/lib/screens/examples/gallery/gallery_example_item.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/widgets.dart';
 
 class GalleryExampleItem {
-  GalleryExampleItem({this.id, this.resource, this.isSvg = false});
+  GalleryExampleItem({
+    required this.id,
+    required this.resource,
+    this.isSvg = false,
+  });
 
   final String id;
   final String resource;
@@ -9,9 +13,11 @@ class GalleryExampleItem {
 }
 
 class GalleryExampleItemThumbnail extends StatelessWidget {
-  const GalleryExampleItemThumbnail(
-      {Key key, this.galleryExampleItem, this.onTap})
-      : super(key: key);
+  const GalleryExampleItemThumbnail({
+    Key? key,
+    required this.galleryExampleItem,
+    required this.onTap,
+  }) : super(key: key);
 
   final GalleryExampleItem galleryExampleItem;
 

--- a/example/lib/screens/examples/hero_example.dart
+++ b/example/lib/screens/examples/hero_example.dart
@@ -28,8 +28,7 @@ class HeroExample extends StatelessWidget {
               child: Image.network(
                 "https://source.unsplash.com/4900x3600/?camera,paper",
                 width: 350.0,
-                loadingBuilder: (_, child, chunk) =>
-                    chunk != null ? const Text("loading") : child,
+                loadingBuilder: (_, child, chunk) => chunk != null ? const Text("loading") : child,
               ),
             ),
           ),
@@ -41,14 +40,14 @@ class HeroExample extends StatelessWidget {
 
 class HeroPhotoViewRouteWrapper extends StatelessWidget {
   const HeroPhotoViewRouteWrapper({
-    this.imageProvider,
+    required this.imageProvider,
     this.backgroundDecoration,
     this.minScale,
     this.maxScale,
   });
 
   final ImageProvider imageProvider;
-  final Decoration backgroundDecoration;
+  final BoxDecoration? backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
 

--- a/example/lib/screens/examples/network_images.dart
+++ b/example/lib/screens/examples/network_images.dart
@@ -27,7 +27,10 @@ class NetworkExamples extends StatelessWidget {
                           child: Text("Loading"),
                         );
                       }
-                      final value = event.cumulativeBytesLoaded / event.expectedTotalBytes!;
+
+                      final value = event.cumulativeBytesLoaded /
+                          (event.expectedTotalBytes ??
+                              event.cumulativeBytesLoaded);
 
                       final percentage = (100 * value).floor();
                       return Center(

--- a/example/lib/screens/examples/network_images.dart
+++ b/example/lib/screens/examples/network_images.dart
@@ -27,8 +27,7 @@ class NetworkExamples extends StatelessWidget {
                           child: Text("Loading"),
                         );
                       }
-                      final value = event.cumulativeBytesLoaded /
-                          event.expectedTotalBytes;
+                      final value = event.cumulativeBytesLoaded / event.expectedTotalBytes!;
 
                       final percentage = (100 * value).floor();
                       return Center(

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -9,7 +9,7 @@ import 'package:photo_view_example/screens/examples/hero_example.dart';
 import 'package:photo_view_example/screens/examples/inline_examples.dart';
 import 'package:photo_view_example/screens/examples/rotation_examples.dart';
 
-import 'examples/network-images.dart';
+import 'examples/network_images.dart';
 
 class HomeScreen extends StatelessWidget {
   @override
@@ -158,7 +158,7 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildItem(context, {String text, Function onPressed}) {
+  Widget _buildItem(context, {required String text, required VoidCallback onPressed}) {
     return FlatButton(
       padding: const EdgeInsets.symmetric(vertical: 25.0, horizontal: 20.0),
       child: Text(

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -158,9 +158,14 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildItem(context, {required String text, required VoidCallback onPressed}) {
-    return FlatButton(
-      padding: const EdgeInsets.symmetric(vertical: 25.0, horizontal: 20.0),
+  Widget _buildItem(context,
+      {required String text, required VoidCallback onPressed}) {
+    return TextButton(
+      style: ButtonStyle(
+        padding: MaterialStateProperty.all(
+          const EdgeInsets.symmetric(vertical: 25.0, horizontal: 20.0),
+        ),
+      ),
       child: Text(
         text,
         style: const TextStyle(fontSize: 18.0, fontWeight: FontWeight.w700),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0-nullsafety.5"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -68,7 +61,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.19.2+1"
+    version: "0.20.0-nullsafety.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -101,21 +94,21 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1+1"
+    version: "0.5.0-nullsafety.0"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0-nullsafety.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0-nullsafety.1"
   photo_view:
     dependency: "direct main"
     description:
@@ -190,7 +183,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "5.0.0-nullsafety.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.24.0-6.0.pre <2.0.0"
+  flutter: ">=1.24.0-7.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +68,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.0"
+    version: "0.19.2+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,28 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   path_drawing:
     dependency: transitive
     description:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.1+1"
   path_parsing:
     dependency: transitive
     description:
@@ -115,14 +115,14 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   photo_view:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.10.3"
+    version: "1.0.0-nullsafety.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -134,63 +134,63 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.5.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-222.0.dev"
-  flutter: ">=1.18.0-6.0.pre <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.24.0-6.0.pre <2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  flutter_svg:
+  flutter_svg: ^0.20.0-nullsafety.3
   photo_view:
     path: ../
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,12 +1,12 @@
 name: photo_view_example
 description: Example of how to use Photo View
 
-publish_to: 'none'
+publish_to: "none"
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter_svg:
@@ -18,7 +18,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
 
 flutter:
   uses-material-design: true

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -12,8 +12,7 @@ import 'package:photo_view/src/utils/photo_view_hero_attributes.dart';
 
 export 'src/controller/photo_view_controller.dart';
 export 'src/controller/photo_view_scalestate_controller.dart';
-export 'src/core/photo_view_gesture_detector.dart'
-    show PhotoViewGestureDetectorScope;
+export 'src/core/photo_view_gesture_detector.dart' show PhotoViewGestureDetectorScope;
 export 'src/photo_view_computed_scale.dart';
 export 'src/photo_view_scale_state.dart';
 export 'src/utils/photo_view_hero_attributes.dart';
@@ -233,8 +232,8 @@ class PhotoView extends StatefulWidget {
   ///
   /// Internally, the image is rendered within an [Image] widget.
   PhotoView({
-    Key key,
-    @required this.imageProvider,
+    Key? key,
+    required this.imageProvider,
     this.loadingBuilder,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
@@ -267,8 +266,8 @@ class PhotoView extends StatefulWidget {
   /// Instead of a [imageProvider], this constructor will receive a [child] and a [childSize].
   ///
   PhotoView.customChild({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
     this.childSize,
     this.backgroundDecoration,
     this.heroAttributes,
@@ -296,17 +295,17 @@ class PhotoView extends StatefulWidget {
 
   /// Given a [imageProvider] it resolves into an zoomable image widget using. It
   /// is required
-  final ImageProvider imageProvider;
+  final ImageProvider? imageProvider;
 
   /// While [imageProvider] is not resolved, [loadingBuilder] is called by [PhotoView]
   /// into the screen, by default it is a centered [CircularProgressIndicator]
-  final LoadingBuilder loadingBuilder;
+  final LoadingBuilder? loadingBuilder;
 
   /// Show loadFailedChild when the image failed to load
-  final ImageErrorWidgetBuilder errorBuilder;
+  final ImageErrorWidgetBuilder? errorBuilder;
 
   /// Changes the background behind image, defaults to `Colors.black`.
-  final Decoration backgroundDecoration;
+  final BoxDecoration? backgroundDecoration;
 
   /// This is used to continue showing the old image (`true`), or briefly show
   /// nothing (`false`), when the `imageProvider` changes. By default it's set
@@ -315,23 +314,23 @@ class PhotoView extends StatefulWidget {
 
   /// Attributes that are going to be passed to [PhotoViewCore]'s
   /// [Hero]. Leave this property undefined if you don't want a hero animation.
-  final PhotoViewHeroAttributes heroAttributes;
+  final PhotoViewHeroAttributes? heroAttributes;
 
   /// Defines the size of the scaling base of the image inside [PhotoView],
   /// by default it is `MediaQuery.of(context).size`.
-  final Size customSize;
+  final Size? customSize;
 
   /// A [Function] to be called whenever the scaleState changes, this happens when the user double taps the content ou start to pinch-in.
-  final ValueChanged<PhotoViewScaleState> scaleStateChangedCallback;
+  final ValueChanged<PhotoViewScaleState>? scaleStateChangedCallback;
 
   /// A flag that enables the rotation gesture support
   final bool enableRotation;
 
   /// The specified custom child to be shown instead of a image
-  final Widget child;
+  final Widget? child;
 
   /// The size of the custom [child]. [PhotoView] uses this value to compute the relation between the child and the container's size to calculate the scale value.
-  final Size childSize;
+  final Size? childSize;
 
   /// Defines the maximum size in which the image will be allowed to assume, it
   /// is proportional to the original image size. Can be either a double (absolute value) or a
@@ -349,38 +348,38 @@ class PhotoView extends StatefulWidget {
   final dynamic initialScale;
 
   /// A way to control PhotoView transformation factors externally and listen to its updates
-  final PhotoViewControllerBase controller;
+  final PhotoViewControllerBase? controller;
 
   /// A way to control PhotoViewScaleState value externally and listen to its updates
-  final PhotoViewScaleStateController scaleStateController;
+  final PhotoViewScaleStateController? scaleStateController;
 
   /// The alignment of the scale origin in relation to the widget size. Default is [Alignment.center]
-  final Alignment basePosition;
+  final Alignment? basePosition;
 
   /// Defines de next [PhotoViewScaleState] given the actual one. Default is [defaultScaleStateCycle]
-  final ScaleStateCycle scaleStateCycle;
+  final ScaleStateCycle? scaleStateCycle;
 
   /// A pointer that will trigger a tap has stopped contacting the screen at a
   /// particular location.
-  final PhotoViewImageTapUpCallback onTapUp;
+  final PhotoViewImageTapUpCallback? onTapUp;
 
   /// A pointer that might cause a tap has contacted the screen at a particular
   /// location.
-  final PhotoViewImageTapDownCallback onTapDown;
+  final PhotoViewImageTapDownCallback? onTapDown;
 
   /// [HitTestBehavior] to be passed to the internal gesture detector.
-  final HitTestBehavior gestureDetectorBehavior;
+  final HitTestBehavior? gestureDetectorBehavior;
 
   /// Enables tight mode, making background container assume the size of the image/child.
   /// Useful when inside a [Dialog]
-  final bool tightMode;
+  final bool? tightMode;
 
   /// Quality levels for image filters.
-  final FilterQuality filterQuality;
+  final FilterQuality? filterQuality;
 
   // Removes gesture detector if `true`.
   // Useful when custom gesture detector is used in child widget.
-  final bool disableGestures;
+  final bool? disableGestures;
 
   bool get _isCustomChild {
     return child != null;
@@ -396,10 +395,10 @@ class _PhotoViewState extends State<PhotoView> {
   // image retrieval
 
   // controller
-  bool _controlledController;
-  PhotoViewControllerBase _controller;
-  bool _controlledScaleStateController;
-  PhotoViewScaleStateController _scaleStateController;
+  late bool _controlledController;
+  late PhotoViewControllerBase _controller;
+  late bool _controlledScaleStateController;
+  late PhotoViewScaleStateController _scaleStateController;
 
   @override
   void initState() {
@@ -410,7 +409,7 @@ class _PhotoViewState extends State<PhotoView> {
       _controller = PhotoViewController();
     } else {
       _controlledController = false;
-      _controller = widget.controller;
+      _controller = widget.controller!;
     }
 
     if (widget.scaleStateController == null) {
@@ -418,7 +417,7 @@ class _PhotoViewState extends State<PhotoView> {
       _scaleStateController = PhotoViewScaleStateController();
     } else {
       _controlledScaleStateController = false;
-      _scaleStateController = widget.scaleStateController;
+      _scaleStateController = widget.scaleStateController!;
     }
 
     _scaleStateController.outputScaleStateStream.listen(scaleStateListener);
@@ -433,7 +432,7 @@ class _PhotoViewState extends State<PhotoView> {
       }
     } else {
       _controlledController = false;
-      _controller = widget.controller;
+      _controller = widget.controller!;
     }
 
     if (widget.scaleStateController == null) {
@@ -443,7 +442,7 @@ class _PhotoViewState extends State<PhotoView> {
       }
     } else {
       _controlledScaleStateController = false;
-      _scaleStateController = widget.scaleStateController;
+      _scaleStateController = widget.scaleStateController!;
     }
     super.didUpdateWidget(oldWidget);
   }
@@ -461,7 +460,7 @@ class _PhotoViewState extends State<PhotoView> {
 
   void scaleStateListener(PhotoViewScaleState scaleState) {
     if (widget.scaleStateChangedCallback != null) {
-      widget.scaleStateChangedCallback(_scaleStateController.scaleState);
+      widget.scaleStateChangedCallback!(_scaleStateController.scaleState);
     }
   }
 
@@ -473,12 +472,13 @@ class _PhotoViewState extends State<PhotoView> {
         BoxConstraints constraints,
       ) {
         final computedOuterSize = widget.customSize ?? constraints.biggest;
+        final backgroundDecoration = widget.backgroundDecoration ?? const BoxDecoration(color: Colors.black);
 
         return widget._isCustomChild
             ? CustomChildWrapper(
                 child: widget.child,
                 childSize: widget.childSize,
-                backgroundDecoration: widget.backgroundDecoration,
+                backgroundDecoration: backgroundDecoration,
                 heroAttributes: widget.heroAttributes,
                 scaleStateChangedCallback: widget.scaleStateChangedCallback,
                 enableRotation: widget.enableRotation,
@@ -498,9 +498,9 @@ class _PhotoViewState extends State<PhotoView> {
                 disableGestures: widget.disableGestures,
               )
             : ImageWrapper(
-                imageProvider: widget.imageProvider,
+                imageProvider: widget.imageProvider!,
                 loadingBuilder: widget.loadingBuilder,
-                backgroundDecoration: widget.backgroundDecoration,
+                backgroundDecoration: backgroundDecoration,
                 gaplessPlayback: widget.gaplessPlayback,
                 heroAttributes: widget.heroAttributes,
                 scaleStateChangedCallback: widget.scaleStateChangedCallback,
@@ -567,5 +567,5 @@ typedef PhotoViewImageTapDownCallback = Function(
 /// A type definition for a callback to show a widget while the image is loading, a [ImageChunkEvent] is passed to inform progress
 typedef LoadingBuilder = Widget Function(
   BuildContext context,
-  ImageChunkEvent event,
+  ImageChunkEvent? event,
 );

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -1,5 +1,6 @@
 library photo_view_gallery;
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:photo_view/photo_view.dart'
     show
@@ -100,8 +101,8 @@ typedef PhotoViewGalleryBuilder = PhotoViewGalleryPageOptions Function(
 class PhotoViewGallery extends StatefulWidget {
   /// Construct a gallery with static items through a list of [PhotoViewGalleryPageOptions].
   const PhotoViewGallery({
-    Key key,
-    @required this.pageOptions,
+    Key? key,
+    required this.pageOptions,
     this.loadingBuilder,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
@@ -115,16 +116,15 @@ class PhotoViewGallery extends StatefulWidget {
     this.customSize,
   })  : itemCount = null,
         builder = null,
-        assert(pageOptions != null),
         super(key: key);
 
   /// Construct a gallery with dynamic items.
   ///
   /// The builder must return a [PhotoViewGalleryPageOptions].
   const PhotoViewGallery.builder({
-    Key key,
-    @required this.itemCount,
-    @required this.builder,
+    Key? key,
+    required this.itemCount,
+    required this.builder,
     this.loadingBuilder,
     this.backgroundDecoration,
     this.gaplessPlayback = false,
@@ -142,22 +142,22 @@ class PhotoViewGallery extends StatefulWidget {
         super(key: key);
 
   /// A list of options to describe the items in the gallery
-  final List<PhotoViewGalleryPageOptions> pageOptions;
+  final List<PhotoViewGalleryPageOptions>? pageOptions;
 
   /// The count of items in the gallery, only used when constructed via [PhotoViewGallery.builder]
-  final int itemCount;
+  final int? itemCount;
 
   /// Called to build items for the gallery when using [PhotoViewGallery.builder]
-  final PhotoViewGalleryBuilder builder;
+  final PhotoViewGalleryBuilder? builder;
 
   /// [ScrollPhysics] for the internal [PageView]
-  final ScrollPhysics scrollPhysics;
+  final ScrollPhysics? scrollPhysics;
 
   /// Mirror to [PhotoView.loadingBuilder]
-  final LoadingBuilder loadingBuilder;
+  final LoadingBuilder? loadingBuilder;
 
   /// Mirror to [PhotoView.backgroundDecoration]
-  final Decoration backgroundDecoration;
+  final BoxDecoration? backgroundDecoration;
 
   /// Mirror to [PhotoView.gaplessPlayback]
   final bool gaplessPlayback;
@@ -166,19 +166,19 @@ class PhotoViewGallery extends StatefulWidget {
   final bool reverse;
 
   /// An object that controls the [PageView] inside [PhotoViewGallery]
-  final PageController pageController;
+  final PageController? pageController;
 
   /// An callback to be called on a page change
-  final PhotoViewGalleryPageChangedCallback onPageChanged;
+  final PhotoViewGalleryPageChangedCallback? onPageChanged;
 
   /// Mirror to [PhotoView.scaleStateChangedCallback]
-  final ValueChanged<PhotoViewScaleState> scaleStateChangedCallback;
+  final ValueChanged<PhotoViewScaleState>? scaleStateChangedCallback;
 
   /// Mirror to [PhotoView.enableRotation]
   final bool enableRotation;
 
   /// Mirror to [PhotoView.customSize]
-  final Size customSize;
+  final Size? customSize;
 
   /// The axis along which the [PageView] scrolls. Mirror to [PageView.scrollDirection]
   final Axis scrollDirection;
@@ -192,29 +192,24 @@ class PhotoViewGallery extends StatefulWidget {
 }
 
 class _PhotoViewGalleryState extends State<PhotoViewGallery> {
-  PageController _controller;
-
-  @override
-  void initState() {
-    _controller = widget.pageController ?? PageController();
-    super.initState();
-  }
+  late final PageController _controller =
+      widget.pageController ?? PageController();
 
   void scaleStateChangedCallback(PhotoViewScaleState scaleState) {
     if (widget.scaleStateChangedCallback != null) {
-      widget.scaleStateChangedCallback(scaleState);
+      widget.scaleStateChangedCallback!(scaleState);
     }
   }
 
   int get actualPage {
-    return _controller.hasClients ? _controller.page.floor() : 0;
+    return _controller.hasClients ? _controller.page!.floor() : 0;
   }
 
   int get itemCount {
     if (widget._isBuilder) {
-      return widget.itemCount;
+      return widget.itemCount!;
     }
-    return widget.pageOptions.length;
+    return widget.pageOptions!.length;
   }
 
   @override
@@ -296,9 +291,9 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
   PhotoViewGalleryPageOptions _buildPageOption(
       BuildContext context, int index) {
     if (widget._isBuilder) {
-      return widget.builder(context, index);
+      return widget.builder!(context, index);
     }
-    return widget.pageOptions[index];
+    return widget.pageOptions![index];
   }
 }
 
@@ -308,8 +303,8 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
 ///
 class PhotoViewGalleryPageOptions {
   PhotoViewGalleryPageOptions({
-    Key key,
-    @required this.imageProvider,
+    Key? key,
+    required this.imageProvider,
     this.heroAttributes,
     this.minScale,
     this.maxScale,
@@ -330,7 +325,7 @@ class PhotoViewGalleryPageOptions {
         assert(imageProvider != null);
 
   PhotoViewGalleryPageOptions.customChild({
-    @required this.child,
+    required this.child,
     this.childSize,
     this.heroAttributes,
     this.minScale,
@@ -347,14 +342,13 @@ class PhotoViewGalleryPageOptions {
     this.filterQuality,
     this.disableGestures,
   })  : errorBuilder = null,
-        imageProvider = null,
-        assert(child != null);
+        imageProvider = null;
 
   /// Mirror to [PhotoView.imageProvider]
-  final ImageProvider imageProvider;
+  final ImageProvider? imageProvider;
 
   /// Mirror to [PhotoView.heroAttributes]
-  final PhotoViewHeroAttributes heroAttributes;
+  final PhotoViewHeroAttributes? heroAttributes;
 
   /// Mirror to [PhotoView.minScale]
   final dynamic minScale;
@@ -366,41 +360,41 @@ class PhotoViewGalleryPageOptions {
   final dynamic initialScale;
 
   /// Mirror to [PhotoView.controller]
-  final PhotoViewController controller;
+  final PhotoViewController? controller;
 
   /// Mirror to [PhotoView.scaleStateController]
-  final PhotoViewScaleStateController scaleStateController;
+  final PhotoViewScaleStateController? scaleStateController;
 
   /// Mirror to [PhotoView.basePosition]
-  final Alignment basePosition;
+  final Alignment? basePosition;
 
   /// Mirror to [PhotoView.child]
-  final Widget child;
+  final Widget? child;
 
   /// Mirror to [PhotoView.childSize]
-  final Size childSize;
+  final Size? childSize;
 
   /// Mirror to [PhotoView.scaleStateCycle]
-  final ScaleStateCycle scaleStateCycle;
+  final ScaleStateCycle? scaleStateCycle;
 
   /// Mirror to [PhotoView.onTapUp]
-  final PhotoViewImageTapUpCallback onTapUp;
+  final PhotoViewImageTapUpCallback? onTapUp;
 
   /// Mirror to [PhotoView.onTapDown]
-  final PhotoViewImageTapDownCallback onTapDown;
+  final PhotoViewImageTapDownCallback? onTapDown;
 
   /// Mirror to [PhotoView.gestureDetectorBehavior]
-  final HitTestBehavior gestureDetectorBehavior;
+  final HitTestBehavior? gestureDetectorBehavior;
 
   /// Mirror to [PhotoView.tightMode]
-  final bool tightMode;
+  final bool? tightMode;
 
   /// Mirror to [PhotoView.disableGestures]
-  final bool disableGestures;
+  final bool? disableGestures;
 
   /// Quality levels for image filters.
-  final FilterQuality filterQuality;
+  final FilterQuality? filterQuality;
 
   /// Mirror to [PhotoView.errorBuilder]
-  final ImageErrorWidgetBuilder errorBuilder;
+  final ImageErrorWidgetBuilder? errorBuilder;
 }

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -25,7 +25,7 @@ typedef PhotoViewGalleryBuilder = PhotoViewGalleryPageOptions Function(
 
 /// A [StatefulWidget] that shows multiple [PhotoView] widgets in a [PageView]
 ///
-/// Some of [PhotoView] constructor options are passed direct to [PhotoViewGallery] cosntructor. Those options will affect the gallery in a whole.
+/// Some of [PhotoView] constructor options are passed direct to [PhotoViewGallery] constructor. Those options will affect the gallery in a whole.
 ///
 /// Some of the options may be defined to each image individually, such as `initialScale` or `heroAttributes`. Those must be passed via each [PhotoViewGalleryPageOptions].
 ///

--- a/lib/src/controller/photo_view_controller.dart
+++ b/lib/src/controller/photo_view_controller.dart
@@ -27,10 +27,10 @@ abstract class PhotoViewControllerBase<T extends PhotoViewControllerValue> {
   Stream<T> get outputStateStream;
 
   /// The state value before the last change or the initial state if the state has not been changed.
-  T prevValue;
+  late T prevValue;
 
   /// The actual state value
-  T value;
+  late T value;
 
   /// Resets the state to the initial value;
   void reset();
@@ -51,26 +51,26 @@ abstract class PhotoViewControllerBase<T extends PhotoViewControllerValue> {
   void removeIgnorableListener(VoidCallback callback);
 
   /// The position of the image in the screen given its offset after pan gestures.
-  Offset position;
+  late Offset position;
 
   /// The scale factor to transform the child (image or a customChild).
-  double scale;
+  late double? scale;
 
   /// Nevermind this method :D, look away
-  void setScaleInvisibly(double scale);
+  void setScaleInvisibly(double? scale);
 
   /// The rotation factor to transform the child (image or a customChild).
-  double rotation;
+  late double rotation;
 
   /// The center of the rotation transformation. It is a coordinate referring to the absolute dimensions of the image.
-  Offset rotationFocusPoint;
+  Offset? rotationFocusPoint;
 
   /// Update multiple fields of the state with only one update streamed.
   void updateMultiple({
-    Offset position,
-    double scale,
-    double rotation,
-    Offset rotationFocusPoint,
+    Offset? position,
+    double? scale,
+    double? rotation,
+    Offset? rotationFocusPoint,
   });
 }
 
@@ -78,16 +78,16 @@ abstract class PhotoViewControllerBase<T extends PhotoViewControllerValue> {
 @immutable
 class PhotoViewControllerValue {
   const PhotoViewControllerValue({
-    @required this.position,
-    @required this.scale,
-    @required this.rotation,
-    @required this.rotationFocusPoint,
+    required this.position,
+    required this.scale,
+    required this.rotation,
+    required this.rotationFocusPoint,
   });
 
   final Offset position;
-  final double scale;
+  final double? scale;
   final double rotation;
-  final Offset rotationFocusPoint;
+  final Offset? rotationFocusPoint;
 
   @override
   bool operator ==(Object other) =>
@@ -124,7 +124,7 @@ class PhotoViewController
   PhotoViewController({
     Offset initialPosition = Offset.zero,
     double initialRotation = 0.0,
-    double initialScale,
+    double? initialScale,
   })  : _valueNotifier = IgnorableValueNotifier(
           PhotoViewControllerValue(
             position: initialPosition,
@@ -144,15 +144,15 @@ class PhotoViewController
 
   final IgnorableValueNotifier<PhotoViewControllerValue> _valueNotifier;
 
-  PhotoViewControllerValue initial;
+  late PhotoViewControllerValue initial;
 
-  StreamController<PhotoViewControllerValue> _outputCtrl;
+  late StreamController<PhotoViewControllerValue> _outputCtrl;
 
   @override
   Stream<PhotoViewControllerValue> get outputStateStream => _outputCtrl.stream;
 
   @override
-  PhotoViewControllerValue prevValue;
+  late PhotoViewControllerValue prevValue;
 
   @override
   void reset() {
@@ -197,7 +197,7 @@ class PhotoViewController
   Offset get position => value.position;
 
   @override
-  set scale(double scale) {
+  set scale(double? scale) {
     if (value.scale == scale) {
       return;
     }
@@ -211,10 +211,10 @@ class PhotoViewController
   }
 
   @override
-  double get scale => value.scale;
+  double? get scale => value.scale;
 
   @override
-  void setScaleInvisibly(double scale) {
+  void setScaleInvisibly(double? scale) {
     if (value.scale == scale) {
       return;
     }
@@ -247,7 +247,7 @@ class PhotoViewController
   double get rotation => value.rotation;
 
   @override
-  set rotationFocusPoint(Offset rotationFocusPoint) {
+  set rotationFocusPoint(Offset? rotationFocusPoint) {
     if (value.rotationFocusPoint == rotationFocusPoint) {
       return;
     }
@@ -261,14 +261,14 @@ class PhotoViewController
   }
 
   @override
-  Offset get rotationFocusPoint => value.rotationFocusPoint;
+  Offset? get rotationFocusPoint => value.rotationFocusPoint;
 
   @override
   void updateMultiple({
-    Offset position,
-    double scale,
-    double rotation,
-    Offset rotationFocusPoint,
+    Offset? position,
+    double? scale,
+    double? rotation,
+    Offset? rotationFocusPoint,
   }) {
     prevValue = value;
     value = PhotoViewControllerValue(

--- a/lib/src/controller/photo_view_controller_delegate.dart
+++ b/lib/src/controller/photo_view_controller_delegate.dart
@@ -28,7 +28,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
   ScaleStateCycle get scaleStateCycle => widget.scaleStateCycle;
 
   Alignment get basePosition => widget.basePosition;
-  Function(double prevScale, double nextScale) _animateScale;
+  Function(double prevScale, double nextScale)? _animateScale;
 
   /// Mark if scale need recalculation, useful for scale boundaries changes.
   bool markNeedsScaleRecalc = true;
@@ -57,7 +57,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
       scaleBoundaries,
     );
 
-    _animateScale(prevScale, nextScale);
+    _animateScale!(prevScale, nextScale);
   }
 
   void addAnimateOnScaleStateUpdate(
@@ -82,7 +82,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
   Offset get position => controller.position;
 
   double get scale {
-    // for initial scale figreing out,
+    // for figuring out initial scale
     final needsRecalc = markNeedsScaleRecalc &&
         !scaleStateController.scaleState.isScaleStateZooming;
 
@@ -96,16 +96,16 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
       scale = newScale;
       return newScale;
     }
-    return controller.scale;
+    return controller.scale!;
   }
 
   set scale(double scale) => controller.setScaleInvisibly(scale);
 
   void updateMultiple({
-    Offset position,
-    double scale,
-    double rotation,
-    Offset rotationFocusPoint,
+    Offset? position,
+    double? scale,
+    double? rotation,
+    Offset? rotationFocusPoint,
   }) {
     controller.updateMultiple(
       position: position,
@@ -155,7 +155,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
     scaleStateController.scaleState = nextScaleState;
   }
 
-  CornersRange cornersX({double scale}) {
+  CornersRange cornersX({double? scale}) {
     final double _scale = scale ?? this.scale;
 
     final double computedWidth = scaleBoundaries.childSize.width * _scale;
@@ -169,7 +169,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
     return CornersRange(minX, maxX);
   }
 
-  CornersRange cornersY({double scale}) {
+  CornersRange cornersY({double? scale}) {
     final double _scale = scale ?? this.scale;
 
     final double computedHeight = scaleBoundaries.childSize.height * _scale;
@@ -183,7 +183,7 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
     return CornersRange(minY, maxY);
   }
 
-  Offset clampPosition({Offset position, double scale}) {
+  Offset clampPosition({Offset? position, double? scale}) {
     final double _scale = scale ?? this.scale;
     final Offset _position = position ?? this.position;
 

--- a/lib/src/controller/photo_view_scalestate_controller.dart
+++ b/lib/src/controller/photo_view_scalestate_controller.dart
@@ -19,25 +19,19 @@ typedef ScaleStateListener = void Function(double prevScale, double nextScale);
 /// The updates should be done via [scaleState] setter and the updated listened via [outputScaleStateStream]
 ///
 class PhotoViewScaleStateController {
-  PhotoViewScaleStateController() {
-    _scaleStateNotifier = IgnorableValueNotifier(PhotoViewScaleState.initial);
-
-    _scaleStateNotifier.addListener(_scaleStateChangeListener);
-    _outputScaleStateCtrl = StreamController<PhotoViewScaleState>.broadcast();
-    _outputScaleStateCtrl.sink.add(PhotoViewScaleState.initial);
-
-    prevScaleState = PhotoViewScaleState.initial;
-  }
-
-  IgnorableValueNotifier<PhotoViewScaleState> _scaleStateNotifier;
-  StreamController<PhotoViewScaleState> _outputScaleStateCtrl;
+  late final IgnorableValueNotifier<PhotoViewScaleState> _scaleStateNotifier =
+      IgnorableValueNotifier(PhotoViewScaleState.initial)
+        ..addListener(_scaleStateChangeListener);
+  final StreamController<PhotoViewScaleState> _outputScaleStateCtrl =
+      StreamController<PhotoViewScaleState>.broadcast()
+        ..sink.add(PhotoViewScaleState.initial);
 
   /// The output for state/value updates
   Stream<PhotoViewScaleState> get outputScaleStateStream =>
       _outputScaleStateCtrl.stream;
 
   /// The state value before the last change or the initial state if the state has not been changed.
-  PhotoViewScaleState prevScaleState;
+  PhotoViewScaleState prevScaleState = PhotoViewScaleState.initial;
 
   /// The actual state value
   PhotoViewScaleState get scaleState => _scaleStateNotifier.value;

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -22,53 +22,53 @@ const _defaultDecoration = const BoxDecoration(
 /// to user gestures, updates to  the controller state and mounts the entire PhotoView Layout
 class PhotoViewCore extends StatefulWidget {
   const PhotoViewCore({
-    Key key,
-    @required this.imageProvider,
-    @required this.backgroundDecoration,
-    @required this.gaplessPlayback,
-    @required this.heroAttributes,
-    @required this.enableRotation,
-    @required this.onTapUp,
-    @required this.onTapDown,
-    @required this.gestureDetectorBehavior,
-    @required this.controller,
-    @required this.scaleBoundaries,
-    @required this.scaleStateCycle,
-    @required this.scaleStateController,
-    @required this.basePosition,
-    @required this.tightMode,
-    @required this.filterQuality,
-    @required this.disableGestures,
-  })  : customChild = null,
+    Key? key,
+    required this.imageProvider,
+    required this.backgroundDecoration,
+    required this.gaplessPlayback,
+    required this.heroAttributes,
+    required this.enableRotation,
+    required this.onTapUp,
+    required this.onTapDown,
+    required this.gestureDetectorBehavior,
+    required this.controller,
+    required this.scaleBoundaries,
+    required this.scaleStateCycle,
+    required this.scaleStateController,
+    required this.basePosition,
+    required this.tightMode,
+    required this.filterQuality,
+    required this.disableGestures,
+  })   : customChild = null,
         super(key: key);
 
   const PhotoViewCore.customChild({
-    Key key,
-    @required this.customChild,
-    @required this.backgroundDecoration,
-    @required this.heroAttributes,
-    @required this.enableRotation,
-    @required this.onTapUp,
-    @required this.onTapDown,
-    @required this.gestureDetectorBehavior,
-    @required this.controller,
-    @required this.scaleBoundaries,
-    @required this.scaleStateCycle,
-    @required this.scaleStateController,
-    @required this.basePosition,
-    @required this.tightMode,
-    @required this.filterQuality,
-    @required this.disableGestures,
-  })  : imageProvider = null,
+    Key? key,
+    required this.customChild,
+    required this.backgroundDecoration,
+    this.heroAttributes,
+    required this.enableRotation,
+    this.onTapUp,
+    this.onTapDown,
+    this.gestureDetectorBehavior,
+    required this.controller,
+    required this.scaleBoundaries,
+    required this.scaleStateCycle,
+    required this.scaleStateController,
+    required this.basePosition,
+    required this.tightMode,
+    required this.filterQuality,
+    required this.disableGestures,
+  })   : imageProvider = null,
         gaplessPlayback = false,
         super(key: key);
 
-  final Decoration backgroundDecoration;
-  final ImageProvider imageProvider;
-  final bool gaplessPlayback;
-  final PhotoViewHeroAttributes heroAttributes;
+  final Decoration? backgroundDecoration;
+  final ImageProvider? imageProvider;
+  final bool? gaplessPlayback;
+  final PhotoViewHeroAttributes? heroAttributes;
   final bool enableRotation;
-  final Widget customChild;
+  final Widget? customChild;
 
   final PhotoViewControllerBase controller;
   final PhotoViewScaleStateController scaleStateController;
@@ -76,10 +76,10 @@ class PhotoViewCore extends StatefulWidget {
   final ScaleStateCycle scaleStateCycle;
   final Alignment basePosition;
 
-  final PhotoViewImageTapUpCallback onTapUp;
-  final PhotoViewImageTapDownCallback onTapDown;
+  final PhotoViewImageTapUpCallback? onTapUp;
+  final PhotoViewImageTapDownCallback? onTapDown;
 
-  final HitTestBehavior gestureDetectorBehavior;
+  final HitTestBehavior? gestureDetectorBehavior;
   final bool tightMode;
   final bool disableGestures;
 
@@ -98,33 +98,38 @@ class PhotoViewCoreState extends State<PhotoViewCore>
         TickerProviderStateMixin,
         PhotoViewControllerDelegate,
         HitCornersDetector {
-  Offset _normalizedPosition;
-  double _scaleBefore;
-  double _rotationBefore;
+  Offset? _normalizedPosition;
+  double? _scaleBefore;
+  double? _rotationBefore;
 
-  AnimationController _scaleAnimationController;
-  Animation<double> _scaleAnimation;
+  late final AnimationController _scaleAnimationController =
+      AnimationController(vsync: this)
+        ..addListener(handleScaleAnimation)
+        ..addStatusListener(onAnimationStatus);
+  Animation<double>? _scaleAnimation;
 
-  AnimationController _positionAnimationController;
-  Animation<Offset> _positionAnimation;
+  late final AnimationController _positionAnimationController =
+      AnimationController(vsync: this)..addListener(handlePositionAnimate);
+  Animation<Offset>? _positionAnimation;
 
-  AnimationController _rotationAnimationController;
-  Animation<double> _rotationAnimation;
+  late final AnimationController _rotationAnimationController =
+      AnimationController(vsync: this)..addListener(handleRotationAnimation);
+  Animation<double>? _rotationAnimation;
 
-  PhotoViewHeroAttributes get heroAttributes => widget.heroAttributes;
+  PhotoViewHeroAttributes? get heroAttributes => widget.heroAttributes;
 
-  ScaleBoundaries cachedScaleBoundaries;
+  late ScaleBoundaries cachedScaleBoundaries = widget.scaleBoundaries;
 
   void handleScaleAnimation() {
-    scale = _scaleAnimation.value;
+    scale = _scaleAnimation!.value;
   }
 
   void handlePositionAnimate() {
-    controller.position = _positionAnimation.value;
+    controller.position = _positionAnimation!.value;
   }
 
   void handleRotationAnimation() {
-    controller.rotation = _rotationAnimation.value;
+    controller.rotation = _rotationAnimation!.value;
   }
 
   void onScaleStart(ScaleStartDetails details) {
@@ -137,8 +142,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   }
 
   void onScaleUpdate(ScaleUpdateDetails details) {
-    final double newScale = _scaleBefore * details.scale;
-    final Offset delta = details.focalPoint - _normalizedPosition;
+    final double newScale = _scaleBefore! * details.scale;
+    final Offset delta = details.focalPoint - _normalizedPosition!;
 
     updateScaleStateFromNewScale(newScale);
 
@@ -147,7 +152,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
       scale: newScale,
       position: clampPosition(position: delta * details.scale),
       rotation:
-          widget.enableRotation ? _rotationBefore + details.rotation : null,
+          widget.enableRotation ? _rotationBefore! + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,
     );
   }
@@ -187,7 +192,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     final double magnitude = details.velocity.pixelsPerSecond.distance;
 
     // animate velocity only if there is no scale change and a significant magnitude
-    if (_scaleBefore / _scale == 1.0 && magnitude >= 400.0) {
+    if (_scaleBefore! / _scale == 1.0 && magnitude >= 400.0) {
       final Offset direction = details.velocity.pixelsPerSecond / magnitude;
       animatePosition(
         _position,
@@ -243,15 +248,6 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   @override
   void initState() {
     super.initState();
-    _scaleAnimationController = AnimationController(vsync: this)
-      ..addListener(handleScaleAnimation);
-    _scaleAnimationController.addStatusListener(onAnimationStatus);
-
-    _positionAnimationController = AnimationController(vsync: this)
-      ..addListener(handlePositionAnimate);
-
-    _rotationAnimationController = AnimationController(vsync: this)
-      ..addListener(handleRotationAnimation);
     initDelegate();
     addAnimateOnScaleStateUpdate(animateOnScaleStateUpdate);
 
@@ -297,7 +293,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
           AsyncSnapshot<PhotoViewControllerValue> snapshot,
         ) {
           if (snapshot.hasData) {
-            final PhotoViewControllerValue value = snapshot.data;
+            final PhotoViewControllerValue value = snapshot.data!;
             final useImageScale = widget.filterQuality != FilterQuality.none;
 
             final computedScale = useImageScale ? 1.0 : scale;
@@ -341,8 +337,12 @@ class PhotoViewCoreState extends State<PhotoViewCore>
               onScaleUpdate: onScaleUpdate,
               onScaleEnd: onScaleEnd,
               hitDetector: this,
-              onTapUp: widget.onTapUp == null ? null : onTapUp,
-              onTapDown: widget.onTapDown == null ? null : onTapDown,
+              onTapUp: widget.onTapUp != null
+                  ? (details) => widget.onTapUp!(context, details, value)
+                  : null,
+              onTapDown: widget.onTapUp != null
+                  ? (details) => widget.onTapDown!(context, details, value)
+                  : null,
             );
           } else {
             return Container();
@@ -353,11 +353,11 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   Widget _buildHero() {
     return heroAttributes != null
         ? Hero(
-            tag: heroAttributes.tag,
-            createRectTween: heroAttributes.createRectTween,
-            flightShuttleBuilder: heroAttributes.flightShuttleBuilder,
-            placeholderBuilder: heroAttributes.placeholderBuilder,
-            transitionOnUserGestures: heroAttributes.transitionOnUserGestures,
+            tag: heroAttributes!.tag,
+            createRectTween: heroAttributes!.createRectTween,
+            flightShuttleBuilder: heroAttributes!.flightShuttleBuilder,
+            placeholderBuilder: heroAttributes!.placeholderBuilder,
+            transitionOnUserGestures: heroAttributes!.transitionOnUserGestures,
             child: _buildChild(),
           )
         : _buildChild();
@@ -365,9 +365,9 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   Widget _buildChild() {
     return widget.hasCustomChild
-        ? widget.customChild
+        ? widget.customChild!
         : Image(
-            image: widget.imageProvider,
+            image: widget.imageProvider!,
             gaplessPlayback: widget.gaplessPlayback ?? false,
             filterQuality: widget.filterQuality,
             width: scaleBoundaries.childSize.width * scale,

--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -5,7 +5,7 @@ import 'photo_view_hit_corners.dart';
 
 class PhotoViewGestureDetector extends StatelessWidget {
   const PhotoViewGestureDetector({
-    Key key,
+    Key? key,
     this.hitDetector,
     this.onScaleStart,
     this.onScaleUpdate,
@@ -17,25 +17,25 @@ class PhotoViewGestureDetector extends StatelessWidget {
     this.behavior,
   }) : super(key: key);
 
-  final GestureDoubleTapCallback onDoubleTap;
-  final HitCornersDetector hitDetector;
+  final GestureDoubleTapCallback? onDoubleTap;
+  final HitCornersDetector? hitDetector;
 
-  final GestureScaleStartCallback onScaleStart;
-  final GestureScaleUpdateCallback onScaleUpdate;
-  final GestureScaleEndCallback onScaleEnd;
+  final GestureScaleStartCallback? onScaleStart;
+  final GestureScaleUpdateCallback? onScaleUpdate;
+  final GestureScaleEndCallback? onScaleEnd;
 
-  final GestureTapUpCallback onTapUp;
-  final GestureTapDownCallback onTapDown;
+  final GestureTapUpCallback? onTapUp;
+  final GestureTapDownCallback? onTapDown;
 
-  final Widget child;
+  final Widget? child;
 
-  final HitTestBehavior behavior;
+  final HitTestBehavior? behavior;
 
   @override
   Widget build(BuildContext context) {
     final scope = PhotoViewGestureDetectorScope.of(context);
 
-    final Axis axis = scope?.axis;
+    final Axis? axis = scope?.axis;
 
     final Map<Type, GestureRecognizerFactory> gestures =
         <Type, GestureRecognizerFactory>{};
@@ -83,17 +83,17 @@ class PhotoViewGestureDetector extends StatelessWidget {
 class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
   PhotoViewGestureRecognizer({
     this.hitDetector,
-    Object debugOwner,
+    Object? debugOwner,
     this.validateAxis,
-    PointerDeviceKind kind,
+    PointerDeviceKind? kind,
   }) : super(debugOwner: debugOwner, kind: kind);
-  final HitCornersDetector hitDetector;
-  final Axis validateAxis;
+  final HitCornersDetector? hitDetector;
+  final Axis? validateAxis;
 
   Map<int, Offset> _pointerLocations = <int, Offset>{};
 
-  Offset _initialFocalPoint;
-  Offset _currentFocalPoint;
+  Offset? _initialFocalPoint;
+  Offset? _currentFocalPoint;
 
   bool ready = true;
 
@@ -140,7 +140,7 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
     final int count = _pointerLocations.keys.length;
     Offset focalPoint = Offset.zero;
     for (int pointer in _pointerLocations.keys)
-      focalPoint += _pointerLocations[pointer];
+      focalPoint += _pointerLocations[pointer]!;
     _currentFocalPoint =
         count > 0 ? focalPoint / count.toDouble() : Offset.zero;
   }
@@ -149,8 +149,8 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
     if (!(event is PointerMoveEvent)) {
       return;
     }
-    final move = _initialFocalPoint - _currentFocalPoint;
-    final bool shouldMove = hitDetector.shouldMove(move, validateAxis);
+    final move = _initialFocalPoint! - _currentFocalPoint!;
+    final bool shouldMove = hitDetector!.shouldMove(move, validateAxis!);
     if (shouldMove || _pointerLocations.keys.length > 1) {
       acceptGesture(event.pointer);
     }
@@ -177,16 +177,16 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
 class PhotoViewGestureDetectorScope extends InheritedWidget {
   PhotoViewGestureDetectorScope({
     this.axis,
-    @required Widget child,
+    required Widget child,
   }) : super(child: child);
 
-  static PhotoViewGestureDetectorScope of(BuildContext context) {
-    final PhotoViewGestureDetectorScope scope = context
+  static PhotoViewGestureDetectorScope? of(BuildContext context) {
+    final PhotoViewGestureDetectorScope? scope = context
         .dependOnInheritedWidgetOfExactType<PhotoViewGestureDetectorScope>();
     return scope;
   }
 
-  final Axis axis;
+  final Axis? axis;
 
   @override
   bool updateShouldNotify(PhotoViewGestureDetectorScope oldWidget) {

--- a/lib/src/core/photo_view_hit_corners.dart
+++ b/lib/src/core/photo_view_hit_corners.dart
@@ -59,8 +59,6 @@ mixin HitCornersDetector on PhotoViewControllerDelegate {
   }
 
   bool shouldMove(Offset move, Axis mainAxis) {
-    assert(mainAxis != null);
-    assert(move != null);
     if (mainAxis == Axis.vertical) {
       return _shouldMoveY(move);
     }

--- a/lib/src/photo_view_default_widgets.dart
+++ b/lib/src/photo_view_default_widgets.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class PhotoViewDefaultError extends StatelessWidget {
-  const PhotoViewDefaultError({Key key, @required this.decoration})
+  const PhotoViewDefaultError({Key? key, required this.decoration})
       : super(key: key);
 
   final BoxDecoration decoration;
@@ -22,15 +22,15 @@ class PhotoViewDefaultError extends StatelessWidget {
 }
 
 class PhotoViewDefaultLoading extends StatelessWidget {
-  const PhotoViewDefaultLoading({Key key, this.event}) : super(key: key);
+  const PhotoViewDefaultLoading({Key? key, this.event}) : super(key: key);
 
-  final ImageChunkEvent event;
+  final ImageChunkEvent? event;
 
   @override
   Widget build(BuildContext context) {
-    final value = event == null
+    final value = event == null || event?.expectedTotalBytes != null
         ? 0.0
-        : event.cumulativeBytesLoaded / event.expectedTotalBytes;
+        : event!.cumulativeBytesLoaded / event!.expectedTotalBytes!;
     return Center(
       child: Container(
         width: 20.0,

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -7,67 +7,67 @@ import 'utils/photo_view_utils.dart';
 
 class ImageWrapper extends StatefulWidget {
   const ImageWrapper({
-    Key key,
-    @required this.imageProvider,
-    @required this.loadingBuilder,
-    @required this.backgroundDecoration,
-    @required this.gaplessPlayback,
-    @required this.heroAttributes,
-    @required this.scaleStateChangedCallback,
-    @required this.enableRotation,
-    @required this.controller,
-    @required this.scaleStateController,
-    @required this.maxScale,
-    @required this.minScale,
-    @required this.initialScale,
-    @required this.basePosition,
-    @required this.scaleStateCycle,
-    @required this.onTapUp,
-    @required this.onTapDown,
-    @required this.outerSize,
-    @required this.gestureDetectorBehavior,
-    @required this.tightMode,
-    @required this.filterQuality,
-    @required this.disableGestures,
-    @required this.errorBuilder,
+    Key? key,
+    required this.imageProvider,
+    required this.loadingBuilder,
+    required this.backgroundDecoration,
+    required this.gaplessPlayback,
+    required this.heroAttributes,
+    required this.scaleStateChangedCallback,
+    required this.enableRotation,
+    required this.controller,
+    required this.scaleStateController,
+    required this.maxScale,
+    required this.minScale,
+    required this.initialScale,
+    required this.basePosition,
+    required this.scaleStateCycle,
+    required this.onTapUp,
+    required this.onTapDown,
+    required this.outerSize,
+    required this.gestureDetectorBehavior,
+    required this.tightMode,
+    required this.filterQuality,
+    required this.disableGestures,
+    required this.errorBuilder,
   }) : super(key: key);
 
   final ImageProvider imageProvider;
-  final LoadingBuilder loadingBuilder;
-  final ImageErrorWidgetBuilder errorBuilder;
-  final Decoration backgroundDecoration;
+  final LoadingBuilder? loadingBuilder;
+  final ImageErrorWidgetBuilder? errorBuilder;
+  final BoxDecoration backgroundDecoration;
   final bool gaplessPlayback;
-  final PhotoViewHeroAttributes heroAttributes;
-  final ValueChanged<PhotoViewScaleState> scaleStateChangedCallback;
+  final PhotoViewHeroAttributes? heroAttributes;
+  final ValueChanged<PhotoViewScaleState>? scaleStateChangedCallback;
   final bool enableRotation;
   final dynamic maxScale;
   final dynamic minScale;
   final dynamic initialScale;
   final PhotoViewControllerBase controller;
   final PhotoViewScaleStateController scaleStateController;
-  final Alignment basePosition;
-  final ScaleStateCycle scaleStateCycle;
-  final PhotoViewImageTapUpCallback onTapUp;
-  final PhotoViewImageTapDownCallback onTapDown;
+  final Alignment? basePosition;
+  final ScaleStateCycle? scaleStateCycle;
+  final PhotoViewImageTapUpCallback? onTapUp;
+  final PhotoViewImageTapDownCallback? onTapDown;
   final Size outerSize;
-  final HitTestBehavior gestureDetectorBehavior;
-  final bool tightMode;
-  final FilterQuality filterQuality;
-  final bool disableGestures;
+  final HitTestBehavior? gestureDetectorBehavior;
+  final bool? tightMode;
+  final FilterQuality? filterQuality;
+  final bool? disableGestures;
 
   @override
   _ImageWrapperState createState() => _ImageWrapperState();
 }
 
 class _ImageWrapperState extends State<ImageWrapper> {
-  ImageStreamListener _imageStreamListener;
-  ImageStream _imageStream;
-  ImageChunkEvent _imageChunkEvent;
-  ImageInfo _imageInfo;
+  ImageStreamListener? _imageStreamListener;
+  ImageStream? _imageStream;
+  ImageChunkEvent? _imageChunkEvent;
+  ImageInfo? _imageInfo;
   bool _loading = true;
-  Size _imageSize;
-  Object _lastException;
-  StackTrace _stackTrace;
+  Size? _imageSize;
+  Object? _lastException;
+  StackTrace? _stackTrace;
 
   // retrieve image from the provider
   void _getImage() {
@@ -99,7 +99,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       synchronousCall ? setupCB() : setState(setupCB);
     }
 
-    void handleError(dynamic error, StackTrace stackTrace) {
+    void handleError(dynamic error, StackTrace? stackTrace) {
       setState(() {
         _loading = false;
         _lastException = error;
@@ -113,22 +113,20 @@ class _ImageWrapperState extends State<ImageWrapper> {
       onError: handleError,
     );
 
-    return _imageStreamListener;
+    return _imageStreamListener!;
   }
 
   void _updateSourceStream(ImageStream newStream) {
     if (_imageStream?.key == newStream.key) {
       return;
     }
-    _imageStream?.removeListener(_imageStreamListener);
+    _imageStream?.removeListener(_imageStreamListener!);
     _imageStream = newStream;
-    _imageStream.addListener(_getOrCreateListener());
+    _imageStream!.addListener(_getOrCreateListener());
   }
 
   void _stopImageStream() {
-    if (_imageStream != null) {
-      _imageStream.removeListener(_imageStreamListener);
-    }
+    _imageStream?.removeListener(_imageStreamListener!);
   }
 
   @override
@@ -166,7 +164,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       widget.maxScale ?? double.infinity,
       widget.initialScale ?? PhotoViewComputedScale.contained,
       widget.outerSize,
-      _imageSize,
+      _imageSize!,
     );
 
     return PhotoViewCore(
@@ -191,11 +189,11 @@ class _ImageWrapperState extends State<ImageWrapper> {
 
   Widget _buildLoading(BuildContext context) {
     if (widget.loadingBuilder != null) {
-      return widget.loadingBuilder(context, _imageChunkEvent);
+      return widget.loadingBuilder!(context, _imageChunkEvent!);
     }
 
     return PhotoViewDefaultLoading(
-      event: _imageChunkEvent,
+      event: _imageChunkEvent!,
     );
   }
 
@@ -203,7 +201,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
     BuildContext context,
   ) {
     if (widget.errorBuilder != null) {
-      return widget.errorBuilder(context, _lastException, _stackTrace);
+      return widget.errorBuilder!(context, _lastException!, _stackTrace);
     }
     return PhotoViewDefaultError(
       decoration: widget.backgroundDecoration,
@@ -213,34 +211,34 @@ class _ImageWrapperState extends State<ImageWrapper> {
 
 class CustomChildWrapper extends StatelessWidget {
   const CustomChildWrapper({
-    Key key,
-    @required this.child,
-    @required this.childSize,
-    @required this.backgroundDecoration,
-    @required this.heroAttributes,
-    @required this.scaleStateChangedCallback,
-    @required this.enableRotation,
-    @required this.controller,
-    @required this.scaleStateController,
-    @required this.maxScale,
-    @required this.minScale,
-    @required this.initialScale,
-    @required this.basePosition,
-    @required this.scaleStateCycle,
-    @required this.onTapUp,
-    @required this.onTapDown,
-    @required this.outerSize,
-    @required this.gestureDetectorBehavior,
-    @required this.tightMode,
-    @required this.filterQuality,
-    @required this.disableGestures,
+    Key? key,
+    this.child,
+    required this.childSize,
+    required this.backgroundDecoration,
+    this.heroAttributes,
+    this.scaleStateChangedCallback,
+    required this.enableRotation,
+    required this.controller,
+    required this.scaleStateController,
+    required this.maxScale,
+    required this.minScale,
+    required this.initialScale,
+    required this.basePosition,
+    required this.scaleStateCycle,
+    this.onTapUp,
+    this.onTapDown,
+    required this.outerSize,
+    this.gestureDetectorBehavior,
+    required this.tightMode,
+    required this.filterQuality,
+    required this.disableGestures,
   }) : super(key: key);
 
-  final Widget child;
-  final Size childSize;
+  final Widget? child;
+  final Size? childSize;
   final Decoration backgroundDecoration;
-  final PhotoViewHeroAttributes heroAttributes;
-  final ValueChanged<PhotoViewScaleState> scaleStateChangedCallback;
+  final PhotoViewHeroAttributes? heroAttributes;
+  final ValueChanged<PhotoViewScaleState>? scaleStateChangedCallback;
   final bool enableRotation;
 
   final PhotoViewControllerBase controller;
@@ -250,15 +248,15 @@ class CustomChildWrapper extends StatelessWidget {
   final dynamic minScale;
   final dynamic initialScale;
 
-  final Alignment basePosition;
-  final ScaleStateCycle scaleStateCycle;
-  final PhotoViewImageTapUpCallback onTapUp;
-  final PhotoViewImageTapDownCallback onTapDown;
+  final Alignment? basePosition;
+  final ScaleStateCycle? scaleStateCycle;
+  final PhotoViewImageTapUpCallback? onTapUp;
+  final PhotoViewImageTapDownCallback? onTapDown;
   final Size outerSize;
-  final HitTestBehavior gestureDetectorBehavior;
-  final bool tightMode;
-  final FilterQuality filterQuality;
-  final bool disableGestures;
+  final HitTestBehavior? gestureDetectorBehavior;
+  final bool? tightMode;
+  final FilterQuality? filterQuality;
+  final bool? disableGestures;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -193,7 +193,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
     }
 
     return PhotoViewDefaultLoading(
-      event: _imageChunkEvent!,
+      event: _imageChunkEvent,
     );
   }
 

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -189,7 +189,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
 
   Widget _buildLoading(BuildContext context) {
     if (widget.loadingBuilder != null) {
-      return widget.loadingBuilder!(context, _imageChunkEvent!);
+      return widget.loadingBuilder!(context, _imageChunkEvent);
     }
 
     return PhotoViewDefaultLoading(

--- a/lib/src/utils/ignorable_change_notifier.dart
+++ b/lib/src/utils/ignorable_change_notifier.dart
@@ -8,7 +8,8 @@ import 'package:flutter/foundation.dart';
 /// The common collection of listeners inherited from [ChangeNotifier] will be fired
 /// every time.
 class IgnorableChangeNotifier extends ChangeNotifier {
-  ObserverList<VoidCallback> _ignorableListeners = ObserverList<VoidCallback>();
+  ObserverList<VoidCallback>? _ignorableListeners =
+      ObserverList<VoidCallback>();
 
   bool _debugAssertNotDisposed() {
     assert(() {
@@ -25,17 +26,17 @@ class IgnorableChangeNotifier extends ChangeNotifier {
 
   @override
   bool get hasListeners {
-    return super.hasListeners || _ignorableListeners.isNotEmpty;
+    return super.hasListeners || (_ignorableListeners?.isNotEmpty ?? false);
   }
 
   void addIgnorableListener(listener) {
     assert(_debugAssertNotDisposed());
-    _ignorableListeners.add(listener);
+    _ignorableListeners!.add(listener);
   }
 
   void removeIgnorableListener(listener) {
     assert(_debugAssertNotDisposed());
-    _ignorableListeners.remove(listener);
+    _ignorableListeners!.remove(listener);
   }
 
   @override
@@ -51,10 +52,10 @@ class IgnorableChangeNotifier extends ChangeNotifier {
     super.notifyListeners();
     if (_ignorableListeners != null) {
       final List<VoidCallback> localListeners =
-          List<VoidCallback>.from(_ignorableListeners);
+          List<VoidCallback>.from(_ignorableListeners!);
       for (VoidCallback listener in localListeners) {
         try {
-          if (_ignorableListeners.contains(listener)) {
+          if (_ignorableListeners!.contains(listener)) {
             listener();
           }
         } catch (exception, stack) {
@@ -70,7 +71,7 @@ class IgnorableChangeNotifier extends ChangeNotifier {
     }
   }
 
-  /// Ignores the ignorables
+  /// Ignores the ignoreables
   @protected
   void notifySomeListeners() {
     super.notifyListeners();

--- a/lib/src/utils/photo_view_hero_attributes.dart
+++ b/lib/src/utils/photo_view_hero_attributes.dart
@@ -4,24 +4,24 @@ import 'package:flutter/widgets.dart';
 /// [PhotoViewImageWrapper]'s [Hero].
 class PhotoViewHeroAttributes {
   const PhotoViewHeroAttributes({
-    @required this.tag,
+    required this.tag,
     this.createRectTween,
     this.flightShuttleBuilder,
     this.placeholderBuilder,
     this.transitionOnUserGestures = false,
-  }) : assert(tag != null);
+  });
 
   /// Mirror to [Hero.tag]
   final Object tag;
 
   /// Mirror to [Hero.createRectTween]
-  final CreateRectTween createRectTween;
+  final CreateRectTween? createRectTween;
 
   /// Mirror to [Hero.flightShuttleBuilder]
-  final HeroFlightShuttleBuilder flightShuttleBuilder;
+  final HeroFlightShuttleBuilder? flightShuttleBuilder;
 
   /// Mirror to [Hero.placeholderBuilder]
-  final HeroPlaceholderBuilder placeholderBuilder;
+  final HeroPlaceholderBuilder? placeholderBuilder;
 
   /// Mirror to [Hero.transitionOnUserGestures]
   final bool transitionOnUserGestures;

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -21,8 +21,9 @@ double getScaleForScaleState(
           scaleBoundaries);
     case PhotoViewScaleState.originalSize:
       return _clampSize(1.0, scaleBoundaries);
+    // Will never be reached
     default:
-      return null;
+      return 0;
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,7 +330,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.12"
+    version: "1.16.0-nullsafety.17"
   test_api:
     dependency: transitive
     description:
@@ -344,7 +344,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.11"
+    version: "0.3.12-nullsafety.15"
   typed_data:
     dependency: transitive
     description:
@@ -395,5 +395,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-31.0.dev"
-  flutter: ">=1.6.0 <2.0.0"
+  dart: ">=2.12.0-0.0 <=2.12.0-224.0.dev"
+  flutter: ">=1.6.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,5 +395,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-224.0.dev"
+  dart: ">=2.12.0-0.0 <=2.12.0-253.0.dev"
   flutter: ">=1.6.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,28 +28,28 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   cli_util:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -178,14 +178,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.6"
   mime:
     dependency: transitive
     description:
@@ -220,7 +220,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   pedantic:
     dependency: transitive
     description:
@@ -295,70 +295,70 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.5"
+    version: "1.16.0-nullsafety.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.5"
+    version: "0.3.12-nullsafety.11"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
   vm_service:
     dependency: transitive
     description:
@@ -395,5 +395,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-222.0.dev"
+  dart: ">=2.12.0-0.0 <=2.12.0-31.0.dev"
   flutter: ">=1.6.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.5.1
+  test: ^1.16.0-nullsafety.17
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: photo_view
-description: Photo View provides a gesture sensitive zoomable widget. Photo View is largely used to show interacive images and other stuff such as SVG.
-version: 0.10.3
+description: Photo View provides a gesture sensitive zoomable widget. Photo View is largely used to show interactive images and other stuff such as SVG.
+version: 1.0.0-nullsafety.0
 homepage: https://github.com/renancaraujo/photo_view
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.6.0 <2.0.0"
 
 dependencies:

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -4,7 +4,7 @@ import 'package:photo_view/src/controller/photo_view_controller.dart';
 import 'package:test/test.dart';
 
 void main() {
-  PhotoViewController controller;
+  late PhotoViewController controller;
   setUp(() {
     controller = PhotoViewController();
   });

--- a/test/scale_state_controller_test.dart
+++ b/test/scale_state_controller_test.dart
@@ -2,7 +2,7 @@ import 'package:photo_view/photo_view.dart';
 import 'package:test/test.dart';
 
 void main() {
-  PhotoViewScaleStateController controller;
+  late PhotoViewScaleStateController controller;
   setUp(() {
     controller = PhotoViewScaleStateController();
   });
@@ -48,7 +48,7 @@ void main() {
 
   test('controller invisible update', () {
     int count = 0;
-    final Function callback = () {
+    final void Function() callback = () {
       count++;
     };
 


### PR DESCRIPTION
As mentioned in #374 this is my PR for the migration to Sound Null Safety. All tests pass but the example will not run in sound null safety mode until [flutter_svg](https://github.com/dnfield/flutter_svg) is migrated. I opened an issue about migration [there](https://github.com/dnfield/flutter_svg/issues/453) as well. 

Closes #374 