### PR TITLE
Fix onScaleEnd operator

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -372,7 +372,7 @@ class PhotoView extends StatefulWidget {
 
   /// A pointer that will trigger a scale has stopped contacting the screen at a
   /// particular location.
-  final PhotoViewImageScaleEndCallback onScaleEnd;
+  final PhotoViewImageScaleEndCallback? onScaleEnd;
 
   /// [HitTestBehavior] to be passed to the internal gesture detector.
   final HitTestBehavior? gestureDetectorBehavior;

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -389,7 +389,7 @@ class PhotoViewGalleryPageOptions {
   final PhotoViewImageTapDownCallback? onTapDown;
 
   /// Mirror to [PhotoView.onScaleEnd]
-  final PhotoViewImageScaleEndCallback onScaleEnd;
+  final PhotoViewImageScaleEndCallback? onScaleEnd;
 
   /// Mirror to [PhotoView.gestureDetectorBehavior]
   final HitTestBehavior? gestureDetectorBehavior;

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -31,7 +31,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.enableRotation,
     required this.onTapUp,
     required this.onTapDown,
-    @required this.onScaleEnd,
+    required this.onScaleEnd,
     required this.gestureDetectorBehavior,
     required this.controller,
     required this.scaleBoundaries,
@@ -81,7 +81,7 @@ class PhotoViewCore extends StatefulWidget {
 
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
-  final PhotoViewImageScaleEndCallback onScaleEnd;
+  final PhotoViewImageScaleEndCallback? onScaleEnd;
 
   final HitTestBehavior? gestureDetectorBehavior;
   final bool tightMode;

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -24,6 +24,7 @@ class ImageWrapper extends StatefulWidget {
     required this.scaleStateCycle,
     required this.onTapUp,
     required this.onTapDown,
+    required this.onScaleEnd,
     required this.outerSize,
     required this.gestureDetectorBehavior,
     required this.tightMode,
@@ -49,6 +50,7 @@ class ImageWrapper extends StatefulWidget {
   final ScaleStateCycle? scaleStateCycle;
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
+  final PhotoViewImageScaleEndCallback? onScaleEnd;
   final Size outerSize;
   final HitTestBehavior? gestureDetectorBehavior;
   final bool? tightMode;
@@ -180,6 +182,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       scaleBoundaries: scaleBoundaries,
       onTapUp: widget.onTapUp,
       onTapDown: widget.onTapDown,
+      onScaleEnd: widget.onScaleEnd,
       gestureDetectorBehavior: widget.gestureDetectorBehavior,
       tightMode: widget.tightMode ?? false,
       filterQuality: widget.filterQuality ?? FilterQuality.none,
@@ -227,6 +230,7 @@ class CustomChildWrapper extends StatelessWidget {
     required this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onScaleEnd,
     required this.outerSize,
     this.gestureDetectorBehavior,
     required this.tightMode,
@@ -252,6 +256,7 @@ class CustomChildWrapper extends StatelessWidget {
   final ScaleStateCycle? scaleStateCycle;
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
+  final PhotoViewImageScaleEndCallback? onScaleEnd;
   final Size outerSize;
   final HitTestBehavior? gestureDetectorBehavior;
   final bool? tightMode;
@@ -280,6 +285,7 @@ class CustomChildWrapper extends StatelessWidget {
       scaleBoundaries: scaleBoundaries,
       onTapUp: onTapUp,
       onTapDown: onTapDown,
+      onScaleEnd: onScaleEnd,
       gestureDetectorBehavior: gestureDetectorBehavior,
       tightMode: tightMode ?? false,
       filterQuality: filterQuality ?? FilterQuality.none,


### PR DESCRIPTION
Gallery could not move caused by onScaleEnd is non-nullable.

onScaleEnd now is non-nullable unlike onTapUp/onTapDown.
I think onScaleEnd should be nullable like onTapUp/onTapDown.

So I added null operator to onScaleEnd.
And change @ required to required like #375 .

After fixed it, Gallery could move.