### PR TITLE
Set PhotoViewGestureRecognizer dragStartBehavior

### DIFF
--- a/example/lib/screens/examples/gallery/gallery_example.dart
+++ b/example/lib/screens/examples/gallery/gallery_example.dart
@@ -12,7 +12,7 @@ class GalleryExample extends StatefulWidget {
 
 class _GalleryExampleState extends State<GalleryExample> {
   bool verticalGallery = false;
-
+  bool borderFlex = false;
   @override
   Widget build(BuildContext context) {
     return ExampleAppBarLayout(
@@ -59,6 +59,20 @@ class _GalleryExampleState extends State<GalleryExample> {
                 ),
               ],
             ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const Text("PageView borderFlex = 5"),
+                Checkbox(
+                  value: borderFlex,
+                  onChanged: (value) {
+                    setState(() {
+                      borderFlex = value!;
+                    });
+                  },
+                ),
+              ],
+            ),
           ],
         ),
       ),
@@ -75,6 +89,7 @@ class _GalleryExampleState extends State<GalleryExample> {
             color: Colors.black,
           ),
           initialIndex: index,
+          borderFlex: borderFlex ? 5 : 0,
           scrollDirection: verticalGallery ? Axis.vertical : Axis.horizontal,
         ),
       ),
@@ -89,9 +104,13 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
     this.minScale,
     this.maxScale,
     this.initialIndex = 0,
+    this.borderFlex = 0,
+    this.photoViewFlex = 100,
     required this.galleryItems,
     this.scrollDirection = Axis.horizontal,
-  }) : pageController = PageController(initialPage: initialIndex);
+  }) : pageController = PageController(
+            initialPage: initialIndex,
+            viewportFraction: (borderFlex + photoViewFlex + borderFlex) / 100);
 
   final LoadingBuilder? loadingBuilder;
   final BoxDecoration? backgroundDecoration;
@@ -101,6 +120,8 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
   final PageController pageController;
   final List<GalleryExampleItem> galleryItems;
   final Axis scrollDirection;
+  final int borderFlex;
+  final int photoViewFlex;
 
   @override
   State<StatefulWidget> createState() {
@@ -137,6 +158,8 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
               pageController: widget.pageController,
               onPageChanged: onPageChanged,
               scrollDirection: widget.scrollDirection,
+              borderFlex: widget.borderFlex,
+              photoViewFlex: widget.photoViewFlex,
             ),
             Container(
               padding: const EdgeInsets.all(20.0),

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -404,7 +404,7 @@ class PhotoView extends StatefulWidget {
   }
 }
 
-class _PhotoViewState extends State<PhotoView> {
+class _PhotoViewState extends State<PhotoView> with AutomaticKeepAliveClientMixin{
   // image retrieval
 
   // controller
@@ -542,6 +542,9 @@ class _PhotoViewState extends State<PhotoView> {
       },
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 /// The default [ScaleStateCycle]

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -115,6 +115,9 @@ class PhotoViewGallery extends StatefulWidget {
     this.scrollPhysics,
     this.scrollDirection = Axis.horizontal,
     this.customSize,
+    this.borderFlex = 0,
+    this.photoViewFlex = 100,
+    this.borderDecoration,
   })  : itemCount = null,
         builder = null,
         super(key: key);
@@ -137,6 +140,9 @@ class PhotoViewGallery extends StatefulWidget {
     this.scrollPhysics,
     this.scrollDirection = Axis.horizontal,
     this.customSize,
+    this.borderFlex = 0,
+    this.photoViewFlex = 100,
+    this.borderDecoration,
   })  : pageOptions = null,
         assert(itemCount != null),
         assert(builder != null),
@@ -184,6 +190,14 @@ class PhotoViewGallery extends StatefulWidget {
   /// The axis along which the [PageView] scrolls. Mirror to [PageView.scrollDirection]
   final Axis scrollDirection;
 
+  /// The borderFlex means the flex in the two borders, which is used in PageController viewportFraction
+  /// PageController viewportFraction = (borderFlex + photoViewFlex + borderFlex) / 100
+  final int borderFlex;
+  final int photoViewFlex;
+
+  /// An Object to draw ViewPortFraction two borders background, if it's null, then default to backgroundDecoration
+  final BoxDecoration? borderDecoration;
+
   bool get _isBuilder => builder != null;
 
   @override
@@ -193,8 +207,11 @@ class PhotoViewGallery extends StatefulWidget {
 }
 
 class _PhotoViewGalleryState extends State<PhotoViewGallery> {
-  late final PageController _controller =
-      widget.pageController ?? PageController();
+  late final PageController _controller = widget.pageController ??
+      PageController(
+          viewportFraction:
+              (widget.borderFlex + widget.photoViewFlex + widget.borderFlex) /
+                  100);
 
   void scaleStateChangedCallback(PhotoViewScaleState scaleState) {
     if (widget.scaleStateChangedCallback != null) {
@@ -286,9 +303,28 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             errorBuilder: pageOption.errorBuilder,
           );
 
-    return ClipRect(
-      child: photoView,
-    );
+    final List<Widget> children = [
+      borderWidget(),
+      Expanded(
+        flex: widget.photoViewFlex,
+        child: ClipRect(
+          child: photoView,
+        ),
+      ),
+      borderWidget()
+    ];
+
+    return widget.scrollDirection == Axis.horizontal
+        ? Row(children: children)
+        : Column(children: children);
+  }
+
+  Widget borderWidget() {
+    return Expanded(
+        flex: widget.borderFlex,
+        child: Container(
+          decoration: widget.borderDecoration ?? widget.backgroundDecoration,
+        ));
   }
 
   PhotoViewGalleryPageOptions _buildPageOption(

--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -66,6 +66,7 @@ class PhotoViewGestureDetector extends StatelessWidget {
           hitDetector: hitDetector, debugOwner: this, validateAxis: axis),
       (PhotoViewGestureRecognizer instance) {
         instance
+          ..dragStartBehavior = DragStartBehavior.start
           ..onStart = onScaleStart
           ..onUpdate = onScaleUpdate
           ..onEnd = onScaleEnd;


### PR DESCRIPTION
According to GestureDector.dragStartBehavior description between DragStartBehavior.start and DragStartBehavior.down, to make image scalable more smoothly, we should set PhotoViewGestureRecognizer dragStartBehavior to DragStartBehavior.start.