### PR TITLE
Fix [BUG] 'PointerEvent' can't be assigned to the parameter type

### DIFF
--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -98,7 +98,7 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
   bool ready = true;
 
   @override
-  void addAllowedPointer(PointerEvent event) {
+  void addAllowedPointer(PointerDownEvent event) {
     if (ready) {
       ready = false;
       _pointerLocations = <int, Offset>{};


### PR DESCRIPTION
This pull request fixes issue #441.

Migrated for the DEV channel of flutter using this article written by the Flutter team https://flutter.dev/docs/release/breaking-changes/gesture-recognizer-add-allowed-pointer


Tested the application on android x86 and arm and seems to be working just fine.