### PR TITLE
Modify addAllowedPointer to accept a PointerDownEvent

### DIFF
--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -98,7 +98,7 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
   bool ready = true;
 
   @override
-  void addAllowedPointer(PointerEvent event) {
+  void addAllowedPointer(PointerDownEvent event) {
     if (ready) {
       ready = false;
       _pointerLocations = <int, Offset>{};


### PR DESCRIPTION
Based on issue #435 and @DizzyYang's find I have changed the overridden addAllowedPointer method (https://api.flutter.dev/flutter/gestures/EagerGestureRecognizer/addAllowedPointer.html) to now accept a PointerDownEvent